### PR TITLE
[fix] scores

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
@@ -45,7 +45,7 @@ class RTDETRPostProcessor(nn.Module):
             boxes = bbox_pred.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, bbox_pred.shape[-1]))
             
         else:
-            scores = F.softmax(logits)[:, :, :-1]
+            scores = F.softmax(logits, dim=-1)
             scores, labels = scores.max(dim=-1)
             boxes = bbox_pred
             if scores.shape[1] > self.num_top_queries:


### PR DESCRIPTION
https://github.com/lyuwenyu/RT-DETR/blob/2b88d5d53bcbfbb70329bc9c007fdf7e76cf90dc/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py#L48

改为

`scores = F.softmax(logits, dim=-1)`

不然最后一个类别无法预测，因为结果被截断了，调试结果如下：

![image](https://github.com/lyuwenyu/RT-DETR/assets/24794718/fd3dfd29-8341-4950-a31a-ec6d93a57a6f)
