### PR TITLE
Fix error due to numpy 2.x incompatibility

### DIFF
--- a/rtdetr_pytorch/requirements.txt
+++ b/rtdetr_pytorch/requirements.txt
@@ -2,6 +2,7 @@ torch==2.0.1
 torchvision==0.15.2
 onnx==1.14.0
 onnxruntime==1.15.1
+numpy==1.26.4
 pycocotools
 PyYAML
 scipy


### PR DESCRIPTION
Fixes `RuntimeError: Could not infer dtype of numpy.uint8` error.