### PR TITLE
:bug: Bugfix: TensorRT output types

### DIFF
--- a/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
+++ b/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
@@ -225,6 +225,6 @@ if __name__ == '__main__':
         'orig_target_sizes': orig_size.to(args.device),
     }
 
-    labels, boxes, scores = m(blob)
+    output = m(blob)
 
-    draw([im_pil], labels, boxes, scores)
+    draw([im_pil], output['labels'], output['boxes'], output['scores'])


### PR DESCRIPTION
**The output of labels, boxes, scores in `rtdetrv2_tensorrt.py` at line 228 should be changed as follows since they are of _*dictionary type*_.**

### Before:

``` python
labels, boxes, scores = m(blob)

draw([im_pil], labels, boxes, scores)
```

### After:
``` python
output = m(blob)

draw([im_pil], output['labels'], output['boxes'], output['scores'])
```
Now, the RT-DETR model converted to TensorRT can produce recognition results correctly.