### PR TITLE
some modifications added to rtdetrv2_torch.py

### DIFF
--- a/rtdetrv2_pytorch/references/deploy/rtdetrv2_torch.py
+++ b/rtdetrv2_pytorch/references/deploy/rtdetrv2_torch.py
@@ -8,7 +8,7 @@ import torchvision.transforms as T
 import numpy as np 
 from PIL import Image, ImageDraw
 
-from cvperception.core import YAMLConfig
+from src.core import YAMLConfig
 
 
 def draw(images, labels, boxes, scores, thrh = 0.6):
@@ -18,10 +18,11 @@ def draw(images, labels, boxes, scores, thrh = 0.6):
         scr = scores[i]
         lab = labels[i][scr > thrh]
         box = boxes[i][scr > thrh]
+        scrs = scores[i][scr > thrh]
 
-        for b in box:
+        for j,b in enumerate(box):
             draw.rectangle(list(b), outline='red',)
-            draw.text((b[0], b[1]), text=str(lab[i].item()), fill='blue', )
+            draw.text((b[0], b[1]), text=f"{lab[j].item()} {round(scrs[j].item(),2)}", fill='blue', )
 
         im.save(f'results_{i}.jpg')
 


### PR DESCRIPTION
There was an import error. The import from `cvperception` changed to `src`. **Now the code should be run from the base directory of rtdetrv2_pytorch.**
The classes of detected boxes were printed wrong on the image. This bug is fixed.
 Also, I added the scores of the detected object to the saved image.