### PR TITLE
fix import error, Copy-on-read Overhead ( called memory leak in repository ) and slightly refactor dist_utils.py for improved readability

### DIFF
--- a/rtdetrv2_pytorch/requirements.txt
+++ b/rtdetrv2_pytorch/requirements.txt
@@ -4,3 +4,5 @@ pycocotools
 PyYAML
 tensorboard
 scipy
+psutil
+tabulate

--- a/rtdetrv2_pytorch/requirements.txt
+++ b/rtdetrv2_pytorch/requirements.txt
@@ -3,3 +3,4 @@ torchvision>=0.15.2
 pycocotools
 PyYAML
 tensorboard
+scipy

--- a/rtdetrv2_pytorch/src/data/dataset/__init__.py
+++ b/rtdetrv2_pytorch/src/data/dataset/__init__.py
@@ -5,7 +5,8 @@
 from .cifar_dataset import CIFAR10
 from .coco_dataset import CocoDetection
 from .coco_dataset import (
-    CocoDetection, 
+    CocoDetection,
+    CocoDetection_share_memory,
     mscoco_category2name, 
     mscoco_category2label,
     mscoco_label2category,

--- a/rtdetrv2_pytorch/src/data/dataset/coco_dataset.py
+++ b/rtdetrv2_pytorch/src/data/dataset/coco_dataset.py
@@ -22,7 +22,7 @@ from ...core import register
 from .coco_utils import TorchSerializedList
 from pycocotools.coco import COCO
 
-__all__ = ['CocoDetection']
+__all__ = ['CocoDetection', 'CocoDetection_share_memory']
 
 
 @register()

--- a/rtdetrv2_pytorch/src/data/dataset/coco_utils.py
+++ b/rtdetrv2_pytorch/src/data/dataset/coco_utils.py
@@ -4,7 +4,8 @@ copy and modified https://github.com/pytorch/vision/blob/main/references/detecti
 Copyright(c) 2023 lyuwenyu. All Rights Reserved.
 """
 
-
+import pickle
+import numpy as np
 import torch
 import torch.utils.data
 import torchvision
@@ -193,3 +194,41 @@ def get_coco_api_from_dataset(dataset):
     return convert_to_coco_api(dataset)
 
 
+class NumpySerializedList():
+    def __init__(self, lst: list):
+        def _serialize(data):
+            buffer = pickle.dumps(data, protocol=-1)
+            return np.frombuffer(buffer, dtype=np.uint8)
+
+        print(
+            "Serializing {} elements to byte tensors and concatenating them all ...".format(
+                len(lst)
+            )
+        )
+        self._lst = [_serialize(x) for x in lst]
+        self._addr = np.asarray([len(x) for x in self._lst], dtype=np.int64)
+        self._addr = np.cumsum(self._addr)
+        self._lst = np.concatenate(self._lst)
+        print("Serialized dataset takes {:.2f} MiB".format(len(self._lst) / 1024**2))
+
+    def __len__(self):
+        return len(self._addr)
+
+    def __getitem__(self, idx):
+        start_addr = 0 if idx == 0 else self._addr[idx - 1].item()
+        end_addr = self._addr[idx].item()
+        bytes = memoryview(self._lst[start_addr:end_addr])
+        return pickle.loads(bytes)
+
+
+class TorchSerializedList(NumpySerializedList):
+    def __init__(self, lst: list):
+        super().__init__(lst)
+        self._addr = torch.from_numpy(self._addr)
+        self._lst = torch.from_numpy(self._lst)
+
+    def __getitem__(self, idx):
+        start_addr = 0 if idx == 0 else self._addr[idx - 1].item()
+        end_addr = self._addr[idx].item()
+        bytes = memoryview(self._lst[start_addr:end_addr].numpy())
+        return pickle.loads(bytes)

--- a/rtdetrv2_pytorch/src/misc/dist_utils.py
+++ b/rtdetrv2_pytorch/src/misc/dist_utils.py
@@ -84,12 +84,7 @@ def setup_print(is_main, method='builtin'):
 
 
 def is_dist_available_and_initialized():
-    if not torch.distributed.is_available():
-        return False
-    if not torch.distributed.is_initialized():
-        return False
-    return True
-
+    return torch.distributed.is_available() and torch.distributed.is_initialized()
 
 @atexit.register
 def cleanup():

--- a/rtdetrv2_pytorch/tools/memory_check.py
+++ b/rtdetrv2_pytorch/tools/memory_check.py
@@ -1,0 +1,169 @@
+import os 
+import sys 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+
+import time
+import pickle
+from collections import defaultdict
+from multiprocessing import Manager
+
+
+from src.data.dataloader import DataLoader, BatchImageCollateFuncion
+from src.data import transforms as T
+from src.data.dataset.coco_dataset import CocoDetection, CocoDetection_share_memory
+
+
+import torch
+import psutil
+from tabulate import tabulate
+
+
+"""
+testing memory usage of dataloader.
+
+requires psutil and tabulate
+
+pip install psutil tabulate
+"""
+
+
+class MemoryMonitor():
+    def __init__(self, pids: list[int] = None):
+        if pids is None:
+            pids = [os.getpid()]
+        self.pids =  Manager().list(pids)
+
+    def add_pid(self, pid: int):
+        assert pid not in self.pids
+        self.pids.append(pid)
+
+    def _refresh(self):
+        self.data = {pid: self.get_mem_info(pid) for pid in self.pids}
+        return self.data
+
+    def table(self) -> str:
+        self._refresh()
+        table = []
+        keys = list(list(self.data.values())[0].keys())
+        now = str(int(time.perf_counter() % 1e5))
+        for pid, data in self.data.items():
+            table.append((now, str(pid)) + tuple(self.format(data[k]) for k in keys))
+        return tabulate(table, headers=["time", "PID"] + keys)
+
+    def str(self):
+        self._refresh()
+        keys = list(list(self.data.values())[0].keys())
+        res = []
+        for pid in self.pids:
+            s = f"PID={pid}"
+            for k in keys:
+                v = self.format(self.data[pid][k])
+                s += f", {k}={v}"
+            res.append(s)
+        return "\n".join(res)
+
+    @staticmethod
+    def format(size: int) -> str:
+        for unit in ('', 'K', 'M', 'G'):
+            if size < 1024:
+                break
+            size /= 1024.0
+        return "%.1f%s" % (size, unit)
+    
+    @staticmethod
+    def get_mem_info(pid: int) -> dict[str, int]:
+        res = defaultdict(int)
+        for mmap in psutil.Process(pid).memory_maps():
+            res['rss'] += mmap.rss
+            res['pss'] += mmap.pss
+            res['uss'] += mmap.private_clean + mmap.private_dirty
+            res['shared'] += mmap.shared_clean + mmap.shared_dirty
+            if mmap.path.startswith('/'):
+                res['shared_file'] += mmap.shared_clean + mmap.shared_dirty
+        return res
+
+
+def test_dataset(
+        dataset_class,
+        range_num=None,
+        img_folder="./dataset/coco/train2017/",
+        ann_file="./dataset/coco/annotations/instances_train2017.json",
+        **kwargs):
+
+    train_dataset = dataset_class(
+        img_folder=img_folder,
+        ann_file=ann_file,
+        transforms = T.Compose([T.RandomPhotometricDistort(p=0.5),
+                                T.RandomZoomOut(fill=0),
+                                T.RandomIoUCrop(p=0.8),
+                                T.SanitizeBoundingBoxes(min_size=1),
+                                T.RandomHorizontalFlip(),
+                                T.Resize(size=[640, 640], ),
+                                T.SanitizeBoundingBoxes(min_size=1),
+                                T.ConvertPILImage(dtype='float32', scale=True),
+                                T.ConvertBoxes(fmt='cxcywh', normalize=True)],
+                                policy={'name': 'stop_epoch',
+                                        'epoch': 71 ,
+                                        'ops': ['RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop']}),
+        return_masks=False,
+        remap_mscoco_category=True,
+        **kwargs)
+    
+    if range_num is not None:
+        train_dataset = torch.utils.data.Subset(train_dataset, range(range_num))
+
+    return train_dataset
+
+
+def test_dataloader(
+        dataset,
+        worker_init_fn,
+        batch_size=4,
+        shuffle=True, 
+        num_workers=4):
+
+    collate_fn = BatchImageCollateFuncion(scales=[480, 512, 544, 576, 608, 640, 640, 640, 672, 704, 736, 768, 800], stop_epoch=71)
+
+    return DataLoader(
+        dataset, 
+        batch_size=batch_size, 
+        shuffle=shuffle, 
+        num_workers=num_workers, 
+        collate_fn=collate_fn, 
+        drop_last=True, 
+        worker_init_fn=worker_init_fn)
+
+
+def main(**kwargs):
+    def hook_pid(worker_id):
+        pid = os.getpid()
+        monitor.pids.append(pid)
+        print(f"tracking {worker_id} PID: {pid}")
+
+    monitor = MemoryMonitor()
+
+    dataloader = test_dataloader(
+        dataset=test_dataset(**kwargs), 
+        worker_init_fn=hook_pid,
+        batch_size=32, 
+        num_workers=2)
+
+    t = time.time()
+
+    for i, (samples, targets) in enumerate(dataloader):
+        # fake read the data
+        samples = pickle.dumps(samples)
+        targets = pickle.dumps(targets)
+
+        if i % 10 == 0:
+            print(monitor.table())
+            print(f"totle pss : {sum([k[1]['pss'] / 1024 / 1024 / 1024 for k in monitor.data.items()]):.3f}GB")
+            print(f"iteration : {i} / {len(dataloader)}, time : {time.time() - t:.3f}")
+            t = time.time()
+
+
+if __name__ == '__main__':
+    # main(dataset_class=CocoDetection, range_num=10000)
+    # main(dataset_class=CocoDetection_share_memory, share_memory=False, range_num=10000)
+    main(dataset_class=CocoDetection_share_memory, share_memory=True, range_num=10000)

--- a/rtdetrv2_pytorch/tools/memory_check.py
+++ b/rtdetrv2_pytorch/tools/memory_check.py
@@ -164,6 +164,6 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    # main(dataset_class=CocoDetection, range_num=10000)
-    # main(dataset_class=CocoDetection_share_memory, share_memory=False, range_num=10000)
-    main(dataset_class=CocoDetection_share_memory, share_memory=True, range_num=10000)
+    # main(dataset_class=CocoDetection, range_num=30000)
+    # main(dataset_class=CocoDetection_share_memory, share_memory=False, range_num=30000)
+    main(dataset_class=CocoDetection_share_memory, share_memory=True, range_num=30000)


### PR DESCRIPTION
Currently, there is a problem with memory exploding in the coco dataset class.

https://github.com/lyuwenyu/RT-DETR/issues/93 https://github.com/lyuwenyu/RT-DETR/issues/172 https://github.com/lyuwenyu/RT-DETR/issues/207 

The cause by Copy-on-read of the Forked CPython object
if you want to explore this problem, check this blog post [Demystify-RAM-Usage-in-Multiprocess-DataLoader](https://ppwwyyxx.com/blog/2022/Demystify-RAM-Usage-in-Multiprocess-DataLoader/)

The CocoDetection_share_memory class uses less total pss memory than current repository coco dataset class. 
This can be found in memory_check.py.