### PR TITLE
Fix Inconsistency Between Training and Inference Caused by Multi-Scale Input Handling

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -307,7 +307,12 @@ class HybridEncoder(nn.Module):
             feat_low = proj_feats[idx - 1]
             feat_high = self.lateral_convs[len(self.in_channels) - 1 - idx](feat_high)
             inner_outs[0] = feat_high
-            upsample_feat = F.interpolate(feat_high, scale_factor=2., mode='nearest')
+            n_low, c_low, h_low, w_low = feat_low.shape
+            n_high, c_high, h_high, w_high = feat_high.shape
+            if h_low == 2 * h_high and w_low == 2 * w_high:
+                upsample_feat = F.interpolate(feat_high, scale_factor=2., mode='nearest')
+            else:
+                upsample_feat = F.interpolate(feat_high, size=(h_low, w_low), mode='bilinear')
             inner_out = self.fpn_blocks[len(self.in_channels)-1-idx](torch.concat([upsample_feat, feat_low], dim=1))
             inner_outs.insert(0, inner_out)
 

--- a/rtdetr_pytorch/src/zoo/rtdetr/rtdetr.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/rtdetr.py
@@ -28,7 +28,11 @@ class RTDETR(nn.Module):
     def forward(self, x, targets=None):
         if self.multi_scale and self.training:
             sz = np.random.choice(self.multi_scale)
-            x = F.interpolate(x, size=[sz, sz])
+            n, c, h, w = x.shape
+            if w > h:  # assuming longer side matches sz
+                x = F.interpolate(x, size=[int(sz * h / w), int(sz)])
+            else:
+                x = F.interpolate(x, size=[int(sz), int(sz * w / h)])
             
         x = self.backbone(x)
         x = self.encoder(x)        


### PR DESCRIPTION
Problem:
Inconsistency issues identified between the training and inference phases related to how multi-scale inputs are handled.

Details:
During training, if the input image's height does not equal its width, our multi-scale process adjusts the image to be square. However, during inference, the inputs are maintained as rectangles. This inconsistency has led to a substantial degradation in model performance, with a decrease in mean Average Precision (mAP) by approximately 20% on our company's datasets.

Modifications:
1. Multi-Scale Feature Interpolation: During training with multi-scale enabled, input images will be resized to match sz, whichever is larger in width or height.
2. HybridEncoder Adjustments: In the HybridEncoder, bilinear interpolation is used for better feature alignment since the scale change is not an integer.
