### PR TITLE
there is any reason torch.autocast(enabled=False) in training?

### DIFF
--- a/rtdetrv2_pytorch/src/solver/det_engine.py
+++ b/rtdetrv2_pytorch/src/solver/det_engine.py
@@ -45,7 +45,7 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
             with torch.autocast(device_type=str(device), cache_enabled=True):
                 outputs = model(samples, targets=targets)
             
-            with torch.autocast(device_type=str(device), enabled=False):
+            with torch.autocast(device_type=str(device)):
                 loss_dict = criterion(outputs, targets, **metas)
 
             loss = sum(loss_dict.values())


### PR DESCRIPTION
i assume that AMP logic is don't work even if use_amp=True or scaler is not None.
because torch.autocast enabled flag is always False

https://github.com/lyuwenyu/RT-DETR/blob/main/rtdetrv2_pytorch/src/solver/det_engine.py#L48
```python
if scaler is not None:
    with torch.autocast(device_type=str(device), cache_enabled=True):
    outputs = model(samples, targets=targets)
            
    with torch.autocast(device_type=str(device), enabled=False):
        loss_dict = criterion(outputs, targets, **metas)
``` 

i check that training speed much faster after fix code
There is any reason that always enabled flag is False? is that bug?

