### PR TITLE
Clamp tgt to avoid NaN in rtdetr_decoder.py

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
@@ -220,7 +220,7 @@ class TransformerDecoderLayer(nn.Module):
         # ffn
         tgt2 = self.forward_ffn(tgt)
         tgt = tgt + self.dropout4(tgt2)
-        tgt = self.norm3(tgt)
+        tgt = self.norm3(tgt.clamp(min=-65504, max=65504))
 
         return tgt
 

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
@@ -220,7 +220,7 @@ class TransformerDecoderLayer(nn.Module):
         # ffn
         tgt2 = self.forward_ffn(tgt)
         tgt = tgt + self.dropout4(tgt2)
-        tgt = self.norm3(tgt)
+        tgt = self.norm3(tgt.clamp(min=-65504, max=65504))
 
         return tgt
 


### PR DESCRIPTION
When pretraining RT-DETR and RT-DETRv2 on Objects365 (decoder number >=6).
After a few more epochs, NaN appears randomly, this is due to AMP training, residual connection after FFN causes tgt to cross the boundary 65504, and clamp can avoid this phenomenon.