### PR TITLE
Sliced Inference Support for Improved Results

### DIFF
--- a/rtdetr_pytorch/tools/infer.py
+++ b/rtdetr_pytorch/tools/infer.py
@@ -1,0 +1,271 @@
+import torch
+import torch.nn as nn 
+import torchvision.transforms as T
+from torch.cuda.amp import autocast
+
+import numpy as np 
+from PIL import Image, ImageDraw, ImageFont
+
+import os 
+import sys 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+import argparse
+
+import src.misc.dist as dist 
+from src.core import YAMLConfig 
+from src.solver import TASKS
+
+
+import numpy as np
+
+def postprocess(labels, boxes, scores, iou_threshold=0.8, distance_threshold=20):
+    def calculate_iou(box1, box2):
+
+        x1, y1, x2, y2 = box1
+        x3, y3, x4, y4 = box2
+
+        xi1 = max(x1, x3)
+        yi1 = max(y1, y3)
+        xi2 = min(x2, x4)
+        yi2 = min(y2, y4)
+
+        inter_width = max(0, xi2 - xi1)
+        inter_height = max(0, yi2 - yi1)
+        inter_area = inter_width * inter_height
+
+        box1_area = (x2 - x1) * (y2 - y1)
+        box2_area = (x4 - x3) * (y4 - y3)
+
+        union_area = box1_area + box2_area - inter_area
+
+        iou = inter_area / union_area if union_area != 0 else 0
+        return iou
+
+    def calculate_centroid_distance(box1, box2):
+        # Calculate the Euclidean distance between the centers of two boxes.
+        x1, y1, x2, y2 = box1
+        x3, y3, x4, y4 = box2
+
+        center_x1 = (x1 + x2) / 2.0
+        center_y1 = (y1 + y2) / 2.0
+        center_x2 = (x3 + x4) / 2.0
+        center_y2 = (y3 + y4) / 2.0
+
+        distance = np.sqrt((center_x1 - center_x2) ** 2 + (center_y1 - center_y2) ** 2)
+        return distance
+
+    merged_labels = []
+    merged_boxes = []
+    merged_scores = []
+    used_indices = set()
+
+    for i in range(len(boxes)):
+        if i in used_indices:
+            continue
+
+        current_box = boxes[i]
+        current_label = labels[i]
+        current_score = scores[i]
+
+        boxes_to_merge = [current_box]
+        scores_to_merge = [current_score]
+        used_indices.add(i)
+
+        for j in range(i + 1, len(boxes)):
+            if j in used_indices:
+                continue
+
+            if labels[j] != current_label:
+                continue  
+
+            other_box = boxes[j]
+
+            iou = calculate_iou(current_box, other_box)
+            distance = calculate_centroid_distance(current_box, other_box)
+
+            if iou >= iou_threshold or distance <= distance_threshold:
+                boxes_to_merge.append(other_box.tolist())  
+                scores_to_merge.append(scores[j])
+                used_indices.add(j)
+
+        xs = np.concatenate([[box[0], box[2]] for box in boxes_to_merge])
+        ys = np.concatenate([[box[1], box[3]] for box in boxes_to_merge])
+
+        merged_box = [np.min(xs), np.min(ys), np.max(xs), np.max(ys)]
+        merged_score = max(scores_to_merge)
+
+        merged_boxes.append(merged_box)
+        merged_labels.append(current_label)
+        merged_scores.append(merged_score)
+
+    return [np.array(merged_labels)], [np.array(merged_boxes)], [np.array(merged_scores)]
+
+
+
+
+
+def slice_image(image, slice_height, slice_width, overlap_ratio):
+    img_width, img_height = image.size
+    
+
+    slices = []
+    coordinates = []
+    step_x = int(slice_width * (1 - overlap_ratio))
+    step_y = int(slice_height * (1 - overlap_ratio))
+    
+    for y in range(0, img_height, step_y):
+        for x in range(0, img_width, step_x):
+            box = (x, y, min(x + slice_width, img_width), min(y + slice_height, img_height))
+            slice_img = image.crop(box)
+            slices.append(slice_img)
+            coordinates.append((x, y))
+
+    return slices, coordinates
+
+
+def merge_predictions(predictions, slice_coordinates, orig_image_size, slice_width, slice_height, threshold=0.6):
+
+    merged_labels = []
+    merged_boxes = []
+    merged_scores = []
+
+    orig_height, orig_width = orig_image_size
+
+    for i, (label, boxes, scores) in enumerate(predictions):
+        x_shift, y_shift = slice_coordinates[i]
+
+        scores = np.array(scores).reshape(-1)
+        valid_indices = scores > threshold
+
+        valid_labels = np.array(label).reshape(-1)[valid_indices]
+        valid_boxes = np.array(boxes).reshape(-1, 4)[valid_indices]
+        valid_scores = scores[valid_indices]
+
+        for j, box in enumerate(valid_boxes):
+            box[0] = np.clip(box[0] + x_shift, 0, orig_width)  
+            box[1] = np.clip(box[1] + y_shift, 0, orig_height)
+            box[2] = np.clip(box[2] + x_shift, 0, orig_width)  
+            box[3] = np.clip(box[3] + y_shift, 0, orig_height) 
+
+            valid_boxes[j] = box
+
+        merged_labels.extend(valid_labels)
+        merged_boxes.extend(valid_boxes)
+        merged_scores.extend(valid_scores)
+
+    return np.array(merged_labels), np.array(merged_boxes), np.array(merged_scores)
+
+
+
+
+
+def draw(images, labels, boxes, scores, thrh = 0.6, path = ""):
+    for i, im in enumerate(images):
+        draw = ImageDraw.Draw(im)
+
+        scr = scores[i]
+        lab = labels[i][scr > thrh]
+        box = boxes[i][scr > thrh]
+        scrs = scores[i][scr > thrh]
+
+        for j,b in enumerate(box):
+            draw.rectangle(list(b), outline='red',)
+            draw.text((b[0], b[1]), text=f"label: {lab[j].item()} {round(scrs[j].item(),2)}", font=ImageFont.load_default(), fill='blue')
+        if path == "":
+            im.save(f'results_{i}.jpg')
+        else:
+            im.save(path)
+            
+
+def main(args, ):
+    """main
+    """
+    cfg = YAMLConfig(args.config, resume=args.resume)
+
+    if args.resume:
+        checkpoint = torch.load(args.resume, map_location='cpu') 
+        if 'ema' in checkpoint:
+            state = checkpoint['ema']['module']
+        else:
+            state = checkpoint['model']
+    else:
+        raise AttributeError('Only support resume to load model.state_dict by now.')
+
+    # NOTE load train mode state -> convert to deploy mode
+    cfg.model.load_state_dict(state)
+
+    class Model(nn.Module):
+        def __init__(self, ) -> None:
+            super().__init__()
+            self.model = cfg.model.deploy()
+            self.postprocessor = cfg.postprocessor.deploy()
+            
+        def forward(self, images, orig_target_sizes):
+            outputs = self.model(images)
+            outputs = self.postprocessor(outputs, orig_target_sizes)
+            return outputs
+    
+    model = Model().to(args.device)
+
+    im_pil = Image.open(args.im_file).convert('RGB')
+    w, h = im_pil.size
+
+    orig_size = torch.tensor([w, h])[None].to(args.device)
+    
+    transforms = T.Compose([
+        T.Resize((640, 640)),  
+        T.ToTensor(),
+    ])
+    im_data = transforms(im_pil)[None].to(args.device)
+
+    if args.sliced:
+        num_boxes = args.numberofboxes
+        
+        aspect_ratio = w / h
+        num_cols = int(np.sqrt(num_boxes * aspect_ratio)) 
+        num_rows = int(num_boxes / num_cols)
+
+        slice_height = h // num_rows
+        slice_width = w // num_cols
+
+        overlap_ratio = 0.2
+
+        slices, coordinates = slice_image(im_pil, slice_height, slice_width, overlap_ratio)
+
+        predictions = []
+        for i, slice_img in enumerate(slices):
+            slice_tensor = transforms(slice_img)[None].to(args.device)
+            with autocast():  # Use AMP for each slice
+                output = model(slice_tensor, torch.tensor([[slice_img.size[0], slice_img.size[1]]]).to(args.device))
+            torch.cuda.empty_cache() 
+            labels, boxes, scores = output
+            
+            labels = labels.cpu().detach().numpy()
+            boxes = boxes.cpu().detach().numpy()
+            scores = scores.cpu().detach().numpy()
+
+            predictions.append((labels, boxes, scores))
+
+        
+        merged_labels, merged_boxes, merged_scores = merge_predictions(predictions, coordinates, (h, w), slice_width, slice_height)
+        labels, boxes, scores = postprocess(merged_labels, merged_boxes, merged_scores, iou_threshold=0.5)
+
+    else:
+        output = model(im_data, orig_size)
+        labels, boxes, scores = output
+        
+    draw([im_pil], labels, boxes, scores, 0.6)
+  
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, )
+    parser.add_argument('-r', '--resume', type=str, )
+    parser.add_argument('-f', '--im-file', type=str, )
+    parser.add_argument('-s', '--sliced', type=bool, default=False)
+    parser.add_argument('-d', '--device', type=str, default='cpu')
+    parser.add_argument('-nc', '--numberofboxes', type=int, default=25)
+
+    args = parser.parse_args()
+    main(args)

--- a/rtdetr_pytorch/tools/infer.py
+++ b/rtdetr_pytorch/tools/infer.py
@@ -18,7 +18,7 @@ from src.solver import TASKS
 
 import numpy as np
 
-def postprocess(labels, boxes, scores, iou_threshold=0.8, distance_threshold=20):
+def postprocess(labels, boxes, scores, iou_threshold=0.8):
     def calculate_iou(box1, box2):
 
         x1, y1, x2, y2 = box1
@@ -40,19 +40,6 @@ def postprocess(labels, boxes, scores, iou_threshold=0.8, distance_threshold=20)
 
         iou = inter_area / union_area if union_area != 0 else 0
         return iou
-
-    def calculate_centroid_distance(box1, box2):
-        # Calculate the Euclidean distance between the centers of two boxes.
-        x1, y1, x2, y2 = box1
-        x3, y3, x4, y4 = box2
-
-        center_x1 = (x1 + x2) / 2.0
-        center_y1 = (y1 + y2) / 2.0
-        center_x2 = (x3 + x4) / 2.0
-        center_y2 = (y3 + y4) / 2.0
-
-        distance = np.sqrt((center_x1 - center_x2) ** 2 + (center_y1 - center_y2) ** 2)
-        return distance
 
     merged_labels = []
     merged_boxes = []
@@ -81,9 +68,8 @@ def postprocess(labels, boxes, scores, iou_threshold=0.8, distance_threshold=20)
             other_box = boxes[j]
 
             iou = calculate_iou(current_box, other_box)
-            distance = calculate_centroid_distance(current_box, other_box)
 
-            if iou >= iou_threshold or distance <= distance_threshold:
+            if iou >= iou_threshold:
                 boxes_to_merge.append(other_box.tolist())  
                 scores_to_merge.append(scores[j])
                 used_indices.add(j)


### PR DESCRIPTION
This pull request supports **sliced window inference to improve object detection results**, especially for larger or high-resolution images. By slicing an image into smaller overlapping windows and running the detection model on each slice, we increase the chances of detecting smaller objects or objects partially visible in a single frame.
The key addition is a slicing mechanism that divides an image into smaller sections before passing it through the detection model. After detection, the predictions from each slice are merged back into the original image space. This method helps detect objects that span slice boundaries while also handling scenarios where a large object might be missed in a single inference pass on the full image.
### Key Changes:
1. The infer.py script now has a slice window inference option, which is enabled by the -sliced flag.
2. Introduced functions to slice images into smaller tiles with a configurable overlap ratio.
3. Implemented postprocessing logic to merge detection results from individual slices back into a single set of predictions.
4. Support for setting the number of slices via the --numberofboxes flag.
### How to Use:
1. When running the inference script, use the—- sliced flag to enable the sliced window inference.
2. You can configure the number of slices by specifying the—- number of boxes argument, which defines how many slices to create based on the image's aspect ratio.
### Results on 0.6 threshold score:
| With Sliced Inference | Without Sliced Inference |
|----------|----------|
| ![results_0](https://github.com/user-attachments/assets/53bbecf7-acb9-47ac-89d6-f00d7fbf5549) | ![results01-withoutsliced](https://github.com/user-attachments/assets/eef89c5b-7eb4-4d19-8abe-9740eae6073e) |
| ![results_withslice](https://github.com/user-attachments/assets/b399e1e2-4f91-4188-9697-d973b8d52f64) | ![results1_wslice](https://github.com/user-attachments/assets/d8f367d1-2750-47a4-9234-1c8d6bd33d6b) |





