### PR TITLE
:bug: Bugfix: [TensorRT Inference] Matching for bbox & label

### DIFF
--- a/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
+++ b/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
@@ -193,9 +193,9 @@ def draw(images, labels, boxes, scores, thrh = 0.6):
         lab = labels[i][scr > thrh]
         box = boxes[i][scr > thrh]
 
-        for b in box:
+        for l, b in enumerate(box):
             draw.rectangle(list(b), outline='red',)
-            draw.text((b[0], b[1]), text=str(lab[i].item()), fill='blue', )
+            draw.text((b[0], b[1]), text=str(lab[l].item()), fill='blue', )
 
         im.save(f'results_{i}.jpg')
 


### PR DESCRIPTION
Hi, lyuwenyu

I found an issue during inference using the TensorRT model.

The problem occurs in the `draw` function at **line 188**, where `text=str(lab[i].item())` is used, causing the labels and bounding boxes to not match correctly in the output.

To resolve this, I applied `enumerate()` to the box and aligned the index information of the box with the corresponding label.

**Below are the images showing the results before and after the bug fix:**
![result](https://github.com/user-attachments/assets/f65530d1-41a4-4c80-ae3e-08c072aa92cf)

**The left** image shows the result **before** the bug fix.
**The right** image shows the result **after** the bug fix.

Looking at the label indexes marked in the images, you can see that before the fix, only a single label was applied incorrectly to multiple detections.

Done!