### PR TITLE
add support to new torchvision version (>=0.16) for rtdetr_pytorch

### DIFF
--- a/rtdetr_pytorch/configs/rtdetr/include/dataloader.yml
+++ b/rtdetr_pytorch/configs/rtdetr/include/dataloader.yml
@@ -9,14 +9,13 @@ train_dataloader:
         - {type: RandomPhotometricDistort, p: 0.5}
         - {type: RandomZoomOut, fill: 0}
         - {type: RandomIoUCrop, p: 0.8}
-        - {type: SanitizeBoundingBox, min_size: 1}
+        - {type: SanitizeBoundingBoxes, min_size: 1}
         - {type: RandomHorizontalFlip}
         - {type: Resize, size: [640, 640], }
         # - {type: Resize, size: 639, max_size: 640}
         # - {type: PadToSize, spatial_size: 640}
-        - {type: ToImageTensor}
-        - {type: ConvertDtype}
-        - {type: SanitizeBoundingBox, min_size: 1}
+        - {type: ConvertPILImage}
+        - {type: SanitizeBoundingBoxes, min_size: 1}
         - {type: ConvertBox, out_fmt: 'cxcywh', normalize: True}
   shuffle: True
   batch_size: 4
@@ -31,8 +30,7 @@ val_dataloader:
         # - {type: Resize, size: 639, max_size: 640}
         # - {type: PadToSize, spatial_size: 640}
         - {type: Resize, size: [640, 640]}
-        - {type: ToImageTensor}
-        - {type: ConvertDtype}
+        - {type: ConvertPILImage}
   shuffle: False
   batch_size: 8
   num_workers: 4

--- a/rtdetr_pytorch/configs/rtdetr/include/dataloader_regnet.yml
+++ b/rtdetr_pytorch/configs/rtdetr/include/dataloader_regnet.yml
@@ -9,14 +9,13 @@ train_dataloader:
         - {type: RandomPhotometricDistort, p: 0.5}
         - {type: RandomZoomOut, fill: 0}
         - {type: RandomIoUCrop, p: 0.8}
-        - {type: SanitizeBoundingBox, min_size: 1}
+        - {type: SanitizeBoundingBoxes, min_size: 1}
         - {type: RandomHorizontalFlip}
         - {type: Resize, size: [640, 640], }
         # - {type: Resize, size: 639, max_size: 640}
         # - {type: PadToSize, spatial_size: 640}
-        - {type: ToImageTensor}
-        - {type: ConvertDtype}
-        - {type: SanitizeBoundingBox, min_size: 1}
+        - {type: ConvertPILImage}
+        - {type: SanitizeBoundingBoxes, min_size: 1}
         - {type: ConvertBox, out_fmt: 'cxcywh', normalize: True}
   shuffle: True
   batch_size: 8
@@ -31,8 +30,7 @@ val_dataloader:
         # - {type: Resize, size: 639, max_size: 640}
         # - {type: PadToSize, spatial_size: 640}
         - {type: Resize, size: [640, 640]}
-        - {type: ToImageTensor}
-        - {type: ConvertDtype}
+        - {type: ConvertPILImage}
   shuffle: False
   batch_size: 8
   num_workers: 2

--- a/rtdetr_pytorch/requirements.txt
+++ b/rtdetr_pytorch/requirements.txt
@@ -1,5 +1,5 @@
-torch
-torchvision
+torch>=2.0.1
+torchvision>=0.15.2
 onnx==1.14.0
 onnxruntime==1.15.1
 pycocotools

--- a/rtdetr_pytorch/requirements.txt
+++ b/rtdetr_pytorch/requirements.txt
@@ -1,5 +1,5 @@
-torch==2.0.1
-torchvision==0.15.2
+torch
+torchvision
 onnx==1.14.0
 onnxruntime==1.15.1
 pycocotools

--- a/rtdetr_pytorch/src/data/coco/coco_dataset.py
+++ b/rtdetr_pytorch/src/data/coco/coco_dataset.py
@@ -11,7 +11,7 @@ import torch.utils.data
 import torchvision
 torchvision.disable_beta_transforms_warning()
 
-from torchvision import datapoints
+from torchvision import tv_tensors
 
 from pycocotools import mask as coco_mask
 
@@ -42,13 +42,13 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 
         # ['boxes', 'masks', 'labels']:
         if 'boxes' in target:
-            target['boxes'] = datapoints.BoundingBox(
+            target['boxes'] = tv_tensors.BoundingBoxes(
                 target['boxes'], 
-                format=datapoints.BoundingBoxFormat.XYXY, 
-                spatial_size=img.size[::-1]) # h w
+                format=tv_tensors.BoundingBoxFormat.XYXY, 
+                canvas_size=img.size[::-1]) # h w
 
         if 'masks' in target:
-            target['masks'] = datapoints.Mask(target['masks'])
+            target['masks'] = tv_tensors.Mask(target['masks'])
 
         if self._transforms is not None:
             img, target = self._transforms(img, target)

--- a/rtdetr_pytorch/src/data/transforms.py
+++ b/rtdetr_pytorch/src/data/transforms.py
@@ -7,11 +7,12 @@ import torch.nn as nn
 
 import torchvision
 torchvision.disable_beta_transforms_warning()
-from torchvision import datapoints
+from torchvision import tv_tensors
 
 import torchvision.transforms.v2 as T
 import torchvision.transforms.v2.functional as F
 
+import PIL
 from PIL import Image 
 from typing import Any, Dict, List, Optional
 
@@ -26,9 +27,9 @@ RandomZoomOut = register(T.RandomZoomOut)
 # RandomIoUCrop = register(T.RandomIoUCrop)
 RandomHorizontalFlip = register(T.RandomHorizontalFlip)
 Resize = register(T.Resize)
-ToImageTensor = register(T.ToImageTensor)
-ConvertDtype = register(T.ConvertDtype)
-SanitizeBoundingBox = register(T.SanitizeBoundingBox)
+ToPureTensor = register(T.ToPureTensor)
+ConvertImageDtype = register(T.ConvertImageDtype)
+SanitizeBoundingBoxes = register(T.SanitizeBoundingBoxes)
 RandomCrop = register(T.RandomCrop)
 Normalize = register(T.Normalize)
 
@@ -70,10 +71,10 @@ class EmptyTransform(T.Transform):
 class PadToSize(T.Pad):
     _transformed_types = (
         Image.Image,
-        datapoints.Image,
-        datapoints.Video,
-        datapoints.Mask,
-        datapoints.BoundingBox,
+        tv_tensors.Image,
+        tv_tensors.Video,
+        tv_tensors.Mask,
+        tv_tensors.BoundingBoxes,
     )
     def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         sz = F.get_spatial_size(flat_inputs[0])
@@ -116,7 +117,7 @@ class RandomIoUCrop(T.RandomIoUCrop):
 @register
 class ConvertBox(T.Transform):
     _transformed_types = (
-        datapoints.BoundingBox,
+        tv_tensors.BoundingBoxes,
     )
     def __init__(self, out_fmt='', normalize=False) -> None:
         super().__init__()
@@ -124,19 +125,41 @@ class ConvertBox(T.Transform):
         self.normalize = normalize
 
         self.data_fmt = {
-            'xyxy': datapoints.BoundingBoxFormat.XYXY,
-            'cxcywh': datapoints.BoundingBoxFormat.CXCYWH
+            'xyxy': tv_tensors.BoundingBoxFormat.XYXY,
+            'cxcywh': tv_tensors.BoundingBoxFormat.CXCYWH
         }
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:  
         if self.out_fmt:
-            spatial_size = inpt.spatial_size
+            spatial_size = inpt.canvas_size
             in_fmt = inpt.format.value.lower()
             inpt = torchvision.ops.box_convert(inpt, in_fmt=in_fmt, out_fmt=self.out_fmt)
-            inpt = datapoints.BoundingBox(inpt, format=self.data_fmt[self.out_fmt], spatial_size=spatial_size)
+            inpt = tv_tensors.BoundingBoxes(inpt, format=self.data_fmt[self.out_fmt], canvas_size=spatial_size)
         
         if self.normalize:
-            inpt = inpt / torch.tensor(inpt.spatial_size[::-1]).tile(2)[None]
+            inpt = inpt / torch.tensor(inpt.canvas_size[::-1]).tile(2)[None]
 
         return inpt
 
+
+@register
+class ConvertPILImage(T.Transform):
+    _transformed_types = (
+        PIL.Image.Image,
+    )
+    def __init__(self, dtype='float32', scale=True) -> None:
+        super().__init__()
+        self.dtype = dtype
+        self.scale = scale
+
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        inpt = F.pil_to_tensor(inpt)
+        if self.dtype == 'float32':
+            inpt = inpt.float()
+
+        if self.scale:
+            inpt = inpt / 255.
+
+        inpt = tv_tensors.Image(inpt)
+
+        return inpt


### PR DESCRIPTION
The original implementation still uses the old `torchvision.datapoints` API which isn't supported by the latest torchvision version (>0.16). So I changed them into `torchvision.tv_tensors`. I have tested this revision in torchvision=0.17.2 and it seems to work well. I added `ConvertPILImage` to convert the image and `/ 255` explicitly, which replaced the original `ToImageTensor` and `ConvertDtype`.