### PR TITLE
add module 'transformers' to requirements.txt

### DIFF
--- a/rtdetr_pytorch/requirements.txt
+++ b/rtdetr_pytorch/requirements.txt
@@ -5,3 +5,4 @@ onnxruntime==1.15.1
 pycocotools
 PyYAML
 scipy
+transformers


### PR DESCRIPTION
Fix the ModuleNotFoundError: No module named 'transformers'
![screenshot of ModuleNotFoundError](https://github.com/user-attachments/assets/e0795c48-55ab-43a8-b40a-9cd511291522)
