### PR TITLE
fix: #561 - NotImplementedError at transforms

### DIFF
--- a/rtdetr_pytorch/src/data/transforms.py
+++ b/rtdetr_pytorch/src/data/transforms.py
@@ -140,3 +140,5 @@ class ConvertBox(T.Transform):
 
         return inpt
 
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)

--- a/rtdetrv2_pytorch/src/data/transforms/_transforms.py
+++ b/rtdetrv2_pytorch/src/data/transforms/_transforms.py
@@ -112,6 +112,9 @@ class ConvertBoxes(T.Transform):
 
         return inpt
 
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
+
 
 @register()
 class ConvertPILImage(T.Transform):
@@ -134,3 +137,6 @@ class ConvertPILImage(T.Transform):
         inpt = Image(inpt)
 
         return inpt
+
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)


### PR DESCRIPTION
This PR fixes issue #561 that occurs in torchvision >= 0.21.

In [#8787](https://github.com/pytorch/vision/pull/8787) of torchvision 0.21, the _transform function of the Transform class was renamed to transform. The function was referenced from forward function, but since transform was not overridden in ConvertBox and ConvertPILImage, a NotImplementedError occurred.
For backward compatibility of dependencies, _transform is left in the transform function.



