### PR TITLE
Add missing module requirements in rtdetrv2_pytorch

### DIFF
--- a/rtdetrv2_pytorch/requirements.txt
+++ b/rtdetrv2_pytorch/requirements.txt
@@ -3,3 +3,5 @@ torchvision>=0.15.2
 faster-coco-eval>=1.6.5
 PyYAML
 tensorboard
+scipy
+pycocotools


### PR DESCRIPTION
Add missing module requirements in rtdetrv2_pytorch
- scipy 
- pycocotools

#585
