### PR TITLE
:sparkles: feat(deploy): Modernize TRT deployment for Blackwell with docs

### DIFF
--- a/rtdetrv2_pytorch/Dockerfile
+++ b/rtdetrv2_pytorch/Dockerfile
@@ -1,5 +1,4 @@
-# tensorrt:23.01-py3 (8.5.2.2)
-FROM nvcr.io/nvidia/tensorrt:23.01-py3
+FROM nvcr.io/nvidia/pytorch:25.06-py3
 
 WORKDIR /workspace
 

--- a/rtdetrv2_pytorch/docker-compose.yml
+++ b/rtdetrv2_pytorch/docker-compose.yml
@@ -1,15 +1,21 @@
-version: "3.9"
-
 services:
   tensorrt-container:
     build:
       context: .
       dockerfile: Dockerfile
-    image: rtdetr-v2:23.01
+    image: rtdetr-v2:25.06
+    container_name: rtdetr-v2-trt
     volumes:
       - ./:/workspace
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    working_dir: /workspace
+    restart: always
     stdin_open: true
     tty: true
+    command: bash

--- a/rtdetrv2_pytorch/docker-compose.yml
+++ b/rtdetrv2_pytorch/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     image: rtdetr-v2:25.06
     container_name: rtdetr-v2-trt
+    ports:
+      - "6006:6006" # tensorboard
     volumes:
       - ./:/workspace
     deploy:
@@ -15,7 +17,7 @@ services:
               count: all
               capabilities: [gpu]
     working_dir: /workspace
-    restart: always
+    restart: unless-stopped
     stdin_open: true
     tty: true
     command: bash

--- a/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
+++ b/rtdetrv2_pytorch/references/deploy/rtdetrv2_tensorrt.py
@@ -1,226 +1,258 @@
-"""Copyright(c) 2023 lyuwenyu. All Rights Reserved.
-"""
+# Copyright 2023 lyuwenyu. All Rights Reserved.
+# Copyright (c) 2025 Hitbee-dev. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+# NOTICE: This file has been heavily modified by [Hitbee-dev] from the original source.
+# Modifications include restructuring for broader GPU architecture compatibility
+# (including NVIDIA Blackwell), improved modularity, and enhanced testability.
+# ==============================================================================
 
-import time 
-import contextlib
-import collections
-from collections import OrderedDict
-
+import time
 import numpy as np
-from PIL import Image, ImageDraw
-import tensorrt as trt
-
 import torch
-import torchvision.transforms as T 
-
-
-
-
-class TimeProfiler(contextlib.ContextDecorator):
-    def __init__(self, ):
-        self.total = 0
-        
-    def __enter__(self, ):
-        self.start = self.time()
-        return self 
-    
-    def __exit__(self, type, value, traceback):
-        self.total += self.time() - self.start
-    
-    def reset(self, ):
-        self.total = 0
-    
-    def time(self, ):
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        return time.time()
-
+import tensorrt as trt
+from collections import OrderedDict
+from PIL import Image, ImageDraw, ImageFont
 
 class TRTInference(object):
-    def __init__(self, engine_path, device='cuda:0', backend='torch', max_batch_size=32, verbose=False):
+    """
+    A high-level wrapper for TensorRT inference, designed for ease of use and flexibility.
+    This class handles engine loading, context creation, and dynamic buffer allocation.
+    """
+    def __init__(self, engine_path, device='cuda:0', verbose=False):
+        """
+        Initializes the TRTInference instance.
+
+        Args:
+            engine_path (str): Path to the serialized TensorRT engine file.
+            device (str): The device to run inference on (e.g., 'cuda:0').
+            verbose (bool): If True, enables verbose logging from the TensorRT logger.
+        """
         self.engine_path = engine_path
-        self.device = device
-        self.backend = backend
-        self.max_batch_size = max_batch_size
+        self.device = torch.device(device)
+        self.logger = trt.Logger(trt.Logger.VERBOSE) if verbose else trt.Logger(trt.Logger.INFO)
         
-        self.logger = trt.Logger(trt.Logger.VERBOSE) if verbose else trt.Logger(trt.Logger.INFO)  
-
-        self.engine = self.load_engine(engine_path)
-
+        trt.init_libnvinfer_plugins(self.logger, '')
+        self.runtime = trt.Runtime(self.logger)
+        self.engine = self._load_engine(engine_path)
         self.context = self.engine.create_execution_context()
 
-        self.bindings = self.get_bindings(self.engine, self.context, self.max_batch_size, self.device)
-        self.bindings_addr = OrderedDict((n, v.ptr) for n, v in self.bindings.items())
+        self.input_names, self.output_names = self._get_io_names()
 
-        self.input_names = self.get_input_names()
-        self.output_names = self.get_output_names()
-        
-        if self.backend == 'cuda':
-            self.stream = cuda.Stream()
+        self.buffers_allocated = False
+        self.gpu_buffers = OrderedDict()
+        self.binding_addrs = OrderedDict()
 
-        self.time_profile = TimeProfiler()
+        print(f"[TRTInference] Initialized successfully. Engine: '{engine_path}'.")
 
-    def init(self, ):
-        self.dynamic = False 
+    def _load_engine(self, path):
+        """Loads a TensorRT engine from a file."""
+        with open(path, 'rb') as f:
+            engine = self.runtime.deserialize_cuda_engine(f.read())
+        if engine is None:
+            raise RuntimeError(f"Failed to load TensorRT engine from '{path}'.")
+        return engine
 
-    def load_engine(self, path):
-        '''load engine
-        '''
-        trt.init_libnvinfer_plugins(self.logger, '')
-        with open(path, 'rb') as f, trt.Runtime(self.logger) as runtime:
-            return runtime.deserialize_cuda_engine(f.read())
-    
-    def get_input_names(self, ):
-        names = []
-        for _, name in enumerate(self.engine):
+    def _get_io_names(self):
+        """Parses input and output tensor names from the engine."""
+        input_names, output_names = [], []
+        for i in range(self.engine.num_io_tensors):
+            name = self.engine.get_tensor_name(i)
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
-                names.append(name)
-        return names
-    
-    def get_output_names(self, ):
-        names = []
-        for _, name in enumerate(self.engine):
-            if self.engine.get_tensor_mode(name) == trt.TensorIOMode.OUTPUT:
-                names.append(name)
-        return names
-
-    def get_bindings(self, engine, context, max_batch_size=32, device=None) -> OrderedDict:
-        '''build binddings
-        '''
-        Binding = collections.namedtuple('Binding', ('name', 'dtype', 'shape', 'data', 'ptr'))
-        bindings = OrderedDict()
-        # max_batch_size = 1
-
-        for i, name in enumerate(engine):
-            shape = engine.get_tensor_shape(name)
-            dtype = trt.nptype(engine.get_tensor_dtype(name))
-
-            if shape[0] == -1:
-                dynamic = True 
-                shape[0] = max_batch_size
-                if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:  # dynamic
-                    context.set_input_shape(name, shape)
-
-            if self.backend == 'cuda':
-                if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
-                    data = np.random.randn(*shape).astype(dtype)
-                    ptr = cuda.mem_alloc(data.nbytes)
-                    bindings[name] = Binding(name, dtype, shape, data, ptr) 
-                else:
-                    data = cuda.pagelocked_empty(trt.volume(shape), dtype)
-                    ptr = cuda.mem_alloc(data.nbytes)
-                    bindings[name] = Binding(name, dtype, shape, data, ptr) 
-
+                input_names.append(name)
             else:
-                data = torch.from_numpy(np.empty(shape, dtype=dtype)).to(device)
-                bindings[name] = Binding(name, dtype, shape, data, data.data_ptr())
+                output_names.append(name)
+        return input_names, output_names
 
-        return bindings
+    def _allocate_buffers(self, blob: dict):
+        """
+        Allocates GPU buffers for inputs and outputs based on the first inference request.
+        This "lazy allocation" strategy handles dynamic input shapes gracefully.
+        """
+        print("[TRTInference] First inference call detected. Allocating GPU buffers...")
+        for name in self.input_names:
+            tensor = blob[name]
+            shape = tuple(tensor.shape)
+            dtype = tensor.dtype
+            self.context.set_input_shape(name, shape)
+            self.gpu_buffers[name] = torch.empty(shape, dtype=dtype, device=self.device)
+            self.binding_addrs[name] = self.gpu_buffers[name].data_ptr()
+            print(f"  - Input '{name}': allocated buffer with shape {shape}.")
 
-    def run_torch(self, blob):
-        '''torch input
-        '''
-        for n in self.input_names:
-            if self.bindings[n].shape != blob[n].shape:
-                self.context.set_input_shape(n, blob[n].shape) 
-                self.bindings[n] = self.bindings[n]._replace(shape=blob[n].shape)
+        for name in self.output_names:
+            shape = tuple(self.context.get_tensor_shape(name))
+            dtype = trt.nptype(self.engine.get_tensor_dtype(name))
+            torch_dtype = torch.from_numpy(np.array(0, dtype=dtype)).dtype
+            self.gpu_buffers[name] = torch.empty(shape, dtype=torch_dtype, device=self.device)
+            self.binding_addrs[name] = self.gpu_buffers[name].data_ptr()
+            print(f"  - Output '{name}': allocated buffer with shape {shape}.")
+
+        self.buffers_allocated = True
+        print("[TRTInference] GPU buffers allocated successfully.")
+
+    def __call__(self, blob: dict):
+        """
+        Executes inference on the loaded TensorRT engine.
+
+        Args:
+            blob (dict): A dictionary mapping input tensor names to their corresponding
+                         torch.Tensor data on the GPU.
+
+        Returns:
+            dict: A dictionary mapping output tensor names to their corresponding
+                  torch.Tensor results on the GPU.
+        """
+        if not self.buffers_allocated:
+            self._allocate_buffers(blob)
             
-            # TODO (lyuwenyu): check dtype,
-            # assert self.bindings[n].data.dtype == blob[n].dtype, '{} dtype mismatch'.format(n)
-            if self.bindings[n].data.dtype != blob[n].shape:
-                blob[n] = blob[n].to(self.bindings[n].data.dtype)
+        for name in self.input_names:
+            self.gpu_buffers[name].copy_(blob[name])
 
-        self.bindings_addr.update({n: blob[n].data_ptr() for n in self.input_names})
-        self.context.execute_v2(list(self.bindings_addr.values()))
-        outputs = {n: self.bindings[n].data for n in self.output_names}
+        self.context.execute_v2(bindings=list(self.binding_addrs.values()))
+        
+        return {name: self.gpu_buffers[name] for name in self.output_names}
 
-        return outputs
+# --- Visualization Utility Function ---
+COCO_CLASSES = [
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+    'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+    'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+    'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+    'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+    'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+    'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard',
+    'cell phone', 'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase',
+    'scissors', 'teddy bear', 'hair drier', 'toothbrush'
+]
 
+def visualize_detections(image_pil, boxes, scores, labels, class_names=COCO_CLASSES, threshold=0.5):
+    """
+    Draws bounding boxes on a PIL image. This function is a general-purpose utility.
 
-    def async_run_cuda(self, blob):
-        '''numpy input
-        '''
-        for n in self.input_names:
-            cuda.memcpy_htod_async(self.bindings_addr[n], blob[n], self.stream)
-        
-        bindings_addr = [int(v) for _, v in self.bindings_addr.items()]
-        self.context.execute_async_v2(bindings=bindings_addr, stream_handle=self.stream.handle)
-        
-        outputs = {}
-        for n in self.output_names:
-            cuda.memcpy_dtoh_async(self.bindings[n].data, self.bindings[n].ptr, self.stream)
-            outputs[n] = self.bindings[n].data
-        
-        self.stream.synchronize()
-        
-        return outputs
+    Args:
+        image_pil (PIL.Image.Image): The image to draw on.
+        boxes (torch.Tensor): A tensor of bounding boxes (shape: [N, 4]).
+        scores (torch.Tensor): A tensor of confidence scores (shape: [N]).
+        labels (torch.Tensor): A tensor of class labels (shape: [N]).
+        class_names (list): A list of strings corresponding to class labels.
+        threshold (float): The confidence threshold for displaying detections.
+
+    Returns:
+        PIL.Image.Image: The image with detections drawn on it.
+    """
+    img_draw = image_pil.copy()
+    draw = ImageDraw.Draw(img_draw)
     
-    def __call__(self, blob):
-        if self.backend == 'torch':
-            return self.run_torch(blob)
-
-        elif self.backend == 'cuda':
-            return self.async_run_cuda(blob)
-
-    def synchronize(self, ):
-        if self.backend == 'torch' and torch.cuda.is_available():
-            torch.cuda.synchronize()
-
-        elif self.backend == 'cuda':
-            self.stream.synchronize()
+    # Ensure tensors are on CPU and converted to NumPy for processing
+    boxes = boxes.cpu().numpy()
+    scores = scores.cpu().numpy()
+    labels = labels.cpu().numpy()
     
-    def warmup(self, blob, n):
-        for _ in range(n):
-            _ = self(blob)
+    count = 0
+    for i in range(len(scores)):
+        score = scores[i]
+        if score < threshold:
+            continue
+        
+        count += 1
+        box = boxes[i]
+        label_idx = int(labels[i])
+        
+        xmin, ymin, xmax, ymax = box
+        class_name = class_names[label_idx] if label_idx < len(class_names) else f'CLS-{label_idx}'
+        color = 'red' # Keep it simple or use a color map
+        
+        draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=color, width=3)
+        
+        text = f"{class_name}: {score:.2f}"
+        
+        try:
+            font = ImageFont.truetype("arial.ttf", 20)
+        except IOError:
+            font = ImageFont.load_default()
 
-    def speed(self, blob, n):
-        self.time_profile.reset()
-        for _ in range(n):
-            with self.time_profile:
-                _ = self(blob)
-
-        return self.time_profile.total / n 
-
-def draw(images, labels, boxes, scores, thrh = 0.6):
-    for i, im in enumerate(images):
-        draw = ImageDraw.Draw(im)
-
-        scr = scores[i]
-        lab = labels[i][scr > thrh]
-        box = boxes[i][scr > thrh]
-
-        for l, b in enumerate(box):
-            draw.rectangle(list(b), outline='red',)
-            draw.text((b[0], b[1]), text=str(lab[l].item()), fill='blue', )
-
-        im.save(f'results_{i}.jpg')
+        text_bbox = draw.textbbox((xmin, ymin), text, font=font)
+        draw.rectangle(text_bbox, fill=color)
+        draw.text((xmin, ymin), text, fill="white", font=font)
+        
+    print(f"   - Found {count} objects above threshold {threshold}.")
+    return img_draw
 
 if __name__ == '__main__':
     import argparse
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-trt', '--trt-file', type=str, required=True)
-    parser.add_argument('-f', '--im-file', type=str, )
-    parser.add_argument('-d', '--device', type=str, default='cuda:0')
+    import torchvision.transforms as T
+    import os
 
+    parser = argparse.ArgumentParser(description="Test script for the TRTInference wrapper.")
+    parser.add_argument('--engine', type=str, required=True, help="Path to the TensorRT engine file.")
+    parser.add_argument('--image', type=str, required=True, help="Path to the input image file.")
+    parser.add_argument('--output', type=str, default='output.jpg', help="Path to save the output image with detections.")
+    parser.add_argument('--device', type=str, default='cuda:0', help="Device to run inference on.")
+    parser.add_argument('--threshold', type=float, default=0.5, help="Confidence threshold for displaying detections.")
     args = parser.parse_args()
-
-    m = TRTInference(args.trt_file, device=args.device)
-
-    im_pil = Image.open(args.im_file).convert('RGB')
-    w, h = im_pil.size
-    orig_size = torch.tensor([w, h])[None].to(args.device)
-
+    
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is not available. This script requires a GPU.")
+    
+    print("--- TRTInference Wrapper Test ---")
+    
+    print("\n1. Initializing TRTInference...")
+    trt_model = TRTInference(args.engine, device=args.device)
+    
+    print("\n2. Preprocessing input image...")
+    image_pil = Image.open(args.image).convert('RGB')
+    w, h = image_pil.size
+    
     transforms = T.Compose([
         T.Resize((640, 640)),
         T.ToTensor(),
     ])
-    im_data = transforms(im_pil)[None]
+    
+    image_tensor = transforms(image_pil).unsqueeze(0).to(args.device)
+    orig_size_tensor = torch.tensor([[w, h]], dtype=torch.int64, device=args.device)
 
     blob = {
-        'images': im_data.to(args.device), 
-        'orig_target_sizes': orig_size.to(args.device),
+        'images': image_tensor,
+        'orig_target_sizes': orig_size_tensor
     }
+    print(f"   - Original image size: {w}x{h}")
+    print(f"   - Input tensor shape: {image_tensor.shape}")
 
-    output = m(blob)
+    print("\n3. Running inference...")
+    start_time = time.time()
+    output_gpu = trt_model(blob)
+    torch.cuda.synchronize()
+    end_time = time.time()
+    
+    print(f"\n4. Inference complete in { (end_time - start_time) * 1000:.2f} ms.")
+    
+    print("\n5. Post-processing and saving output image...")
+    output_labels = output_gpu['labels'][0]
+    output_boxes = output_gpu['boxes'][0]
+    output_scores = output_gpu['scores'][0]
+    
+    # Use the new, separate visualization function
+    result_image = visualize_detections(
+        image_pil, 
+        output_boxes, 
+        output_scores, 
+        output_labels, 
+        threshold=args.threshold
+    )
+    
+    result_image.save(args.output)
+    print(f"   - Output image with detections saved to: {os.path.abspath(args.output)}")
 
-    draw([im_pil], output['labels'], output['boxes'], output['scores'])
+    print("\n--- Test finished successfully ---")

--- a/rtdetrv2_pytorch/requirements.txt
+++ b/rtdetrv2_pytorch/requirements.txt
@@ -1,5 +1,3 @@
-torch>=2.0.1
-torchvision>=0.15.2
 faster-coco-eval>=1.6.5
 PyYAML
 tensorboard
@@ -7,4 +5,3 @@ scipy
 pycocotools
 onnx
 onnxruntime-gpu
-tensorrt==8.5.2.2

--- a/rtdetrv2_pytorch/tools/README.md
+++ b/rtdetrv2_pytorch/tools/README.md
@@ -1,24 +1,96 @@
+### Getting Started: Environment & Workflow
 
+This guide provides a complete workflow from setting up the environment to training, exporting, and running inference with TensorRT.
 
-Train/test script examples
-- `CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 --master-port=8989 tools/train.py -c path/to/config &> train.log 2>&1 &`
-- `-r path/to/checkpoint`
-- `--amp`
-- `--test-only` 
+#### **1. Environment Setup with Docker**
 
+First, build and run the pre-configured Docker environment. This is the recommended way to ensure all dependencies and drivers are correctly aligned.
 
-Export script examples
-- `python tools/export_onnx.py -c path/to/config -r path/to/checkpoint --check`
+*   **Step 1.1: Clone the repository** (if you haven't already)
+    ```bash
+    git clone https://github.com/lyuwenyu/RT-DETR.git
+    cd RT-DETR
+    ```
 
+*   **Step 1.2: Build and run the services in the background**
+    From the project root directory, run:
+    ```bash
+    docker compose up --build -d
+    ```
+    *   `--build`: Forces a rebuild of the Docker image if the `Dockerfile` has changed.
+    *   `-d`: Runs the containers in detached mode (in the background).
 
-Gpu do not release memory
-- `ps aux | grep "tools/train.py" | awk '{print $2}' | xargs kill -9`
+*   **Step 1.3: Access the running container**
+    All subsequent commands should be run inside the container. To get a shell inside it:
+    ```bash
+    docker exec -it rtdetr-rtdetrv2_pytorch-1 bash
+    ```
+    *(Note: Your container name might be slightly different. Use `docker ps` to check.)*
 
+---
 
-Save all logs
-- Appending `&> train.log 2>&1 &` or `&> train.log 2>&1`
+#### **2. Training & Evaluation**
 
+*   **To start or resume training** on 4 GPUs, use `torchrun`. Appending `&> train.log 2>&1 &` will run it in the background and save all logs.
 
-Tensorboard
-- `--summary-dir=/path/to/summary/dir` or `-u summary_dir=/path/to/summary/dir`
-- `tensorboard --host=ip --port=8989 --logdir=/path/to/summary/`
+    ```bash
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 --master-port=8989 \
+        tools/train.py -c path/to/config.yml \
+        -r path/to/checkpoint_to_resume_from.pth \
+        --amp
+    ```
+
+*   **To run evaluation only**, add the `--test-only` flag to the training command.
+
+    ```bash
+    CUDA_VISIBLE_DEVICES=0 torchrun --nproc_per_node=1 tools/train.py \
+        -c path/to/config.yml \
+        -r path/to/trained_checkpoint.pth \
+        --test-only
+    ```
+
+#### **3. Exporting Models for Deployment**
+
+First, export the trained PyTorch model to the ONNX format. Then, for maximum performance on NVIDIA GPUs, convert the ONNX model to a TensorRT engine.
+
+*   **Step 3.1: Export to ONNX**
+
+    ```bash
+    python tools/export_onnx.py \
+        -c path/to/config.yml \
+        -r path/to/trained_checkpoint.pth \
+        --check
+    ```
+
+*   **Step 3.2: Convert ONNX to TensorRT Engine**
+
+    Use the provided `onnx2trt.sh` script. It takes the ONNX file path and saves the resulting `.trt` engine in the same directory.
+
+    ```bash
+    bash tools/onnx2trt.sh /path/to/your/model.onnx
+    ```
+
+#### **4. Running Inference with TensorRT**
+
+Use the `rtdetrv2_tensorrt.py` script to run inference on a single image with your generated TensorRT engine.
+
+```bash
+python references/deploy/rtdetrv2_tensorrt.py \
+    --engine /path/to/your/model.trt \
+    --image /path/to/your/image.jpg \
+    --output /path/to/save/output.jpg \
+    --threshold 0.5
+```
+
+### Utilities & Tips
+- **Visualize training with TensorBoard**
+  - Add `--summary-dir=/path/to/summary/dir` to your training command.
+  - Launch TensorBoard:
+    ``` bash
+    tensorboard --host=0.0.0.0 --port=8989 --logdir=/path/to/summary/
+    ```
+  - **Forcefully release GPU memory** if a process gets stuck:
+    - **Warning:** This is a drastic measure. use with caution.
+    ``` bash
+    ps aux | grep "tools/train.py" | awk '{print $2}' | xargs kill -9
+    ```

--- a/rtdetrv2_pytorch/tools/README.md
+++ b/rtdetrv2_pytorch/tools/README.md
@@ -1,96 +1,124 @@
-### Getting Started: Environment & Workflow
+### Getting Started: A Complete Workflow
 
-This guide provides a complete workflow from setting up the environment to training, exporting, and running inference with TensorRT.
+This guide provides a complete, step-by-step workflow from setting up the environment to training, exporting, and running inference with TensorRT.
 
-#### **1. Environment Setup with Docker**
+#### **1. Environment Setup with Docker (Recommended)**
 
-First, build and run the pre-configured Docker environment. This is the recommended way to ensure all dependencies and drivers are correctly aligned.
+Using Docker is the recommended way to ensure all dependencies, drivers, and CUDA versions are perfectly aligned. This eliminates "it works on my machine" issues.
 
-*   **Step 1.1: Clone the repository** (if you haven't already)
-    ```bash
-    git clone https://github.com/lyuwenyu/RT-DETR.git
-    cd RT-DETR
-    ```
+*   **Step 1.1: Build and Run the Container**
 
-*   **Step 1.2: Build and run the services in the background**
-    From the project root directory, run:
+    From the project's root directory, run `docker compose`. This will build the image based on the `Dockerfile` and start the service in the background.
+
     ```bash
     docker compose up --build -d
     ```
-    *   `--build`: Forces a rebuild of the Docker image if the `Dockerfile` has changed.
-    *   `-d`: Runs the containers in detached mode (in the background).
 
-*   **Step 1.3: Access the running container**
-    All subsequent commands should be run inside the container. To get a shell inside it:
+*   **Step 1.2: Verify the Container is Running**
+
+    Check that the container is up and running. Note its name for the next step.
     ```bash
-    docker exec -it rtdetr-rtdetrv2_pytorch-1 bash
+    docker ps
     ```
-    *(Note: Your container name might be slightly different. Use `docker ps` to check.)*
 
 ---
 
-#### **2. Training & Evaluation**
+#### **2. Training & Evaluation (Using `docker attach`)**
 
-*   **To start or resume training** on 4 GPUs, use `torchrun`. Appending `&> train.log 2>&1 &` will run it in the background and save all logs.
+This method directly attaches your terminal to the container's main process. It's simple but requires careful handling to avoid terminating your session.
+
+*   **Step 2.1: Attach to the Container**
+
+    Attach your terminal to the running container. You will be dropped into a bash shell.
 
     ```bash
-    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 --master-port=8989 \
-        tools/train.py -c path/to/config.yml \
-        -r path/to/checkpoint_to_resume_from.pth \
+    docker attach <your_container_name>
+    ```
+
+*   **Step 2.2: Run the Training Command**
+
+    Now, *inside the attached shell*, run your training command. `torchrun` will automatically use the GPUs assigned to the container. **Do not run it in the background (`&`)**.
+
+    ```bash
+    # Example for 4 GPUs assigned to the container
+    torchrun --nproc_per_node=4 --master-port=8989 \
+        tools/train.py -c configs/rtdetr/rtdetr_r50vd_6x_coco.yml \
         --amp
     ```
 
-*   **To run evaluation only**, add the `--test-only` flag to the training command.
+*   **Step 2.3: Detach from the Session (IMPORTANT!)**
+
+    With your training running, you can safely detach and leave it running.
+
+    **WARNING:** **DO NOT PRESS `Ctrl+C`**. This will kill the training process and potentially the entire container.
+
+    To safely detach, press the sequence: **`Ctrl+P`**, followed immediately by **`Ctrl+Q`**.
+
+    You will return to your local terminal, and the container will continue running the training in the background.
+
+*   **Step 2.4: Re-attach to Your Session**
+
+    To check on your training progress, simply run the `docker attach` command again. You will see the live output from your training command.
 
     ```bash
-    CUDA_VISIBLE_DEVICES=0 torchrun --nproc_per_node=1 tools/train.py \
-        -c path/to/config.yml \
-        -r path/to/trained_checkpoint.pth \
-        --test-only
+    docker attach <your_container_name>
+    ```
+    (Remember to detach with `Ctrl+P`, `Ctrl+Q` when you're done.)
+
+---
+
+#### **3. Exporting & Inference**
+
+For tasks like exporting or running inference, which don't need to run for days, it's safer to use `docker exec` to open a new, separate shell.
+
+*   **Step 3.1: Open a New Shell in the Container**
+    ```bash
+    docker exec -it <your_container_name> bash
     ```
 
-#### **3. Exporting Models for Deployment**
-
-First, export the trained PyTorch model to the ONNX format. Then, for maximum performance on NVIDIA GPUs, convert the ONNX model to a TensorRT engine.
-
-*   **Step 3.1: Export to ONNX**
-
+*   **Step 3.2: Run Export or Inference Commands**
+    Now, inside this new shell, run your commands.
     ```bash
+    # Export to ONNX
     python tools/export_onnx.py \
-        -c path/to/config.yml \
+        -c configs/rtdetr/rtdetr_r50vd_6x_coco.yml \
         -r path/to/trained_checkpoint.pth \
         --check
     ```
-
-*   **Step 3.2: Convert ONNX to TensorRT Engine**
-
-    Use the provided `onnx2trt.sh` script. It takes the ONNX file path and saves the resulting `.trt` engine in the same directory.
-
-    ```bash
+    
+    ```
+    # Convert to TensorRT
     bash tools/onnx2trt.sh /path/to/your/model.onnx
     ```
 
-#### **4. Running Inference with TensorRT**
-
-Use the `rtdetrv2_tensorrt.py` script to run inference on a single image with your generated TensorRT engine.
-
-```bash
-python references/deploy/rtdetrv2_tensorrt.py \
+    ```
+    # RUN TRT Inference
+    python references/deploy/rtdetrv2_tensorrt.py \
     --engine /path/to/your/model.trt \
     --image /path/to/your/image.jpg \
     --output /path/to/save/output.jpg \
     --threshold 0.5
-```
+    ```
 
 ### Utilities & Tips
-- **Visualize training with TensorBoard**
-  - Add `--summary-dir=/path/to/summary/dir` to your training command.
-  - Launch TensorBoard:
-    ``` bash
-    tensorboard --host=0.0.0.0 --port=8989 --logdir=/path/to/summary/
+
+*   **Visualize training with TensorBoard:**
+    *   Use the standard port `6006` to avoid conflicts with training.
+    *   Ensure the port `6006` is exposed in your `docker-compose.yml`.
+
+    ```bash
+    # Inside the container
+    tensorboard --logdir=path/to/summary/ --host=0.0.0.0 --port=6006
     ```
-  - **Forcefully release GPU memory** if a process gets stuck:
-    - **Warning:** This is a drastic measure. use with caution.
-    ``` bash
-    ps aux | grep "tools/train.py" | awk '{print $2}' | xargs kill -9
-    ```
+
+*   **Managing the Container Lifecycle:**
+    *   **To temporarily stop** the container without deleting it (e.g., to pause training and resume later):
+        ```bash
+        docker compose stop
+        ```
+        You can restart it later with `docker compose start`.
+
+    *   **To stop and completely remove** the container, network, and volumes:
+        ```bash
+        docker compose down
+        ```

--- a/rtdetrv2_pytorch/tools/onnx2trt.sh
+++ b/rtdetrv2_pytorch/tools/onnx2trt.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# A script to convert an ONNX model to a TensorRT engine using trtexec.
+# This script automatically sets the output engine path based on the input ONNX file.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Check if an input file is provided.
+if [ -z "$1" ]; then
+    echo "Error: No ONNX file provided."
+    echo "Usage: $0 /path/to/your/model.onnx"
+    exit 1
+fi
+
+ONNX_FILE=$1
+# Replace the .onnx extension with .trt for the output file.
+ENGINE_FILE="${ONNX_FILE%.onnx}.trt"
+
+echo "==> Converting ONNX to TensorRT Engine <=="
+echo "  - Input ONNX:  $ONNX_FILE"
+echo "  - Output TRT:  $ENGINE_FILE"
+echo "  - Precision:   FP16"
+echo "=========================================="
+
+# Run the trtexec command.
+# --fp16 enables 16-bit floating-point precision for faster inference.
+# --verbose provides detailed output during the conversion process.
+trtexec --onnx="$ONNX_FILE" \
+        --saveEngine="$ENGINE_FILE" \
+        --fp16 \
+        --verbose
+
+echo "=========================================="
+echo "✅ Successfully created TensorRT engine: $ENGINE_FILE"


### PR DESCRIPTION
### [Feature] Add NVIDIA Blackwell Support & Modernize TensorRT Deployment

Hi @lyuwenyu 

It's great to connect with you again! Following my previous contributions in PRs #395 and #480, I'm thrilled to have another opportunity to contribute. Your RT-DETR repository has been an incredible foundation for my work, and it's inspired me to explore its potential on the very latest hardware.

This pull request provides critical updates to enable RT-DETR deployment on NVIDIA's new **Blackwell** architecture. The existing deployment scripts and environment were incompatible with the newer drivers and libraries required for Blackwell, failing at both the ONNX-to-TRT conversion and the final inference stages. This PR addresses these issues comprehensively, delivering a modernized, robust, and future-proof deployment workflow.

---

### **Key Changes by File**

1.  **`Dockerfile` & `requirements.txt`:**
    *   **Switched Base Image** to `nvcr.io/nvidia/pytorch:25.06-py3` to provide the necessary CUDA toolkit and library support for the Blackwell architecture.
    *   **Optimized Dependencies** to align with the new base image.

2.  **`references/deploy/rtdetrv2_tensorrt.py`:**
    *   **Major Refactoring** to resolve API and logic incompatibilities with the newer TensorRT libraries. The new implementation is cleaner, more modular, and uses a robust "lazy" buffer allocation strategy.
    *   **Enhanced Standalone Testability** with command-line arguments (`--engine`, `--image`, etc.) and a built-in visualization function to save inference results as an image file.

3.  **`tools/onnx2trt.sh` (New Addition):**
    *   A new, **flexible `trtexec` wrapper script** that takes the ONNX file path as an argument, replacing hardcoded paths and standardizing the conversion process.

4.  **`docker-compose.yml`:**
    *   **Aligned** with the new `Dockerfile` to simplify local development setup.

5.  **`README.md`:**
    *   **Completely restructured** the usage examples into a clear, step-by-step workflow: **Environment Setup -> Training -> Exporting -> Inference**. This significantly improves usability for new users and provides explicit instructions for using Docker.

---

### **Extensive Testing & Validation**

This entire workflow has been extensively tested and validated across the following NVIDIA GPU architectures to ensure broad, stable compatibility:
*   ✅ **Ampere:** RTX 3070, RTX 3090, A6000
*   ✅ **Ada Lovelace:** RTX 4080 Super, 6000 Ada, L40S
*   ✅ **Blackwell:** RTX 5070

#### **Sample Test Run on Blackwell (RTX 5070)**
<img width="1796" height="759" alt="image" src="https://github.com/user-attachments/assets/f41f3a3e-c434-47e0-8c23-afa7e4a90df3" />


The updated `rtdetrv2_tensorrt.py` script provides the following output, demonstrating a successful end-to-end test run:
``` bash
root@93d0e80b0b44:/workspace/references/deploy# python rtdetrv2_tensorrt.py --engine ./rtdetr_pretrained.trt --image ./test1.jpg
--- TRTInference Wrapper Test ---

Initializing TRTInference...
[07/14/2025-16:34:11] [TRT] [I] Loaded engine size: 88 MiB
...
[TRTInference] Initialized successfully. Engine: './rtdetr_pretrained.trt'.
Preprocessing input image...
Original image size: 640x543
Input tensor shape: torch.Size([1, 3, 640, 640])
Running inference...
[TRTInference] First inference call detected. Allocating GPU buffers...
...
[TRTInference] GPU buffers allocated successfully.
Inference complete in 33.43 ms.
Post-processing and saving output image...
Found 21 objects above threshold 0.5.
Output image with detections saved to: /workspace/references/deploy/output.jpg
--- Test finished successfully ---
```

Thank you again for maintaining this fantastic project. I hope this contribution helps the community leverage the power of RT-DETR on the next generation of hardware!
