### PR TITLE
Fix PadToSize impl to follow Transform API after torchvision 0.21

### DIFF
--- a/rtdetr_pytorch/src/data/transforms.py
+++ b/rtdetr_pytorch/src/data/transforms.py
@@ -81,6 +81,9 @@ class PadToSize(T.Pad):
         self.padding = [0, 0, w, h]
         return dict(padding=self.padding)
 
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+        return self._get_params(flat_inputs)
+
     def __init__(self, spatial_size, fill=0, padding_mode='constant') -> None:
         if isinstance(spatial_size, int):
             spatial_size = (spatial_size, spatial_size)
@@ -92,6 +95,9 @@ class PadToSize(T.Pad):
         fill = self._fill[type(inpt)]
         padding = params['padding']
         return F.pad(inpt, padding=padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
+
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
 
     def __call__(self, *inputs: Any) -> Any:
         outputs = super().forward(*inputs)

--- a/rtdetrv2_pytorch/src/data/transforms/_transforms.py
+++ b/rtdetrv2_pytorch/src/data/transforms/_transforms.py
@@ -59,6 +59,9 @@ class PadToSize(T.Pad):
         self.padding = [0, 0, w, h]
         return dict(padding=self.padding)
 
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+        return self._get_params(flat_inputs)
+
     def __init__(self, size, fill=0, padding_mode='constant') -> None:
         if isinstance(size, int):
             size = (size, size)
@@ -69,6 +72,9 @@ class PadToSize(T.Pad):
         fill = self._fill[type(inpt)]
         padding = params['padding']
         return F.pad(inpt, padding=padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
+
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
 
     def __call__(self, *inputs: Any) -> Any:
         outputs = super().forward(*inputs)


### PR DESCRIPTION
This PR fixes `PadToSize` transform in torchvision >= 0.21.

Related issue: #584

In pytorch/vision#8787 of torchvision 0.21,
1. the `_transform()` function of the `Transform` class was renamed to `transform()`. The function was referenced from forward function, but since transform was not overridden in `PadToSize`, a `NotImplementedError` occurred.
For backward compatibility of dependencies, `_transform()` is left in the `transform()` function.

2. the `_get_params()` function of the `Transform` class was renamed to `make_params()`. The `padding` param will not be calculated in `PadToSize`.
For backward compatibility of dependencies, `_get_params()` is left in the `make_params()` function.
