### PR TITLE
fix(rtdetrv2): use converted boxes in softmax postprocess branch

### DIFF
--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
@@ -62,8 +62,9 @@ class RTDETRPostProcessor(nn.Module):
             boxes = bbox_pred.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, bbox_pred.shape[-1]))
             
         else:
-            scores = F.softmax(logits)[:, :, :-1]
+            scores = F.softmax(logits, dim=-1)[:, :, :-1]
             scores, labels = scores.max(dim=-1)
+            boxes = bbox_pred
             if scores.shape[1] > self.num_top_queries:
                 scores, index = torch.topk(scores, self.num_top_queries, dim=-1)
                 labels = torch.gather(labels, dim=1, index=index)


### PR DESCRIPTION
Fix `RTDETRPostProcessor` in `rtdetrv2_pytorch` when `use_focal_loss=False`.

In the softmax branch, postprocessing should operate on `bbox_pred`, i.e. boxes that have already been converted from normalized `cxcywh` to scaled `xyxy` coordinates. Without this, the branch may return raw normalized `pred_boxes` when top-k filtering is not triggered.

This PR:
- uses `bbox_pred` in the softmax branch before optional top-k selection
- makes the softmax dimension explicit with `F.softmax(..., dim=-1)`
- preserves exclusion of the final no-object class via `[:, :, :-1]`
