### PR TITLE
fix(benchmark): derive num classes from prediction shape in yolov8_onnx

### DIFF
--- a/benchmark/yolov8_onnx.py
+++ b/benchmark/yolov8_onnx.py
@@ -26,7 +26,8 @@ class YOLOv8(torch.nn.Module):
         '''
         pred: torch.Tensor = self.model(x)[0] # n 84 8400,
         pred = pred.permute(0, 2, 1)
-        boxes, scores = pred.split([4, 80], dim=-1)
+        nc = pred.shape[-1] - 4
+        boxes, scores = pred.split([4, nc], dim=-1)
         boxes = torchvision.ops.box_convert(boxes, in_fmt='cxcywh', out_fmt='xyxy')
 
         return boxes, scores


### PR DESCRIPTION
## Summary
`benchmark/yolov8_onnx.py` hardcoded the class count to 80 in `pred.split([4, 80], dim=-1)`, which assumes COCO. Exporting a YOLOv8 model trained on a custom dataset (e.g. 20 or 1000 classes) raises a split-size mismatch.

## Change
Derive number of classes from the prediction tensor.