### PR TITLE
fix(paddle): support Pillow 10 in debug visualization

### DIFF
--- a/rtdetr_paddle/ppdet/data/transform/operators.py
+++ b/rtdetr_paddle/ppdet/data/transform/operators.py
@@ -2068,7 +2068,8 @@ class DebugVisibleImage(BaseOperator):
                 fill='green')
             # draw label
             text = str(gt_class[i][0])
-            tw, th = draw.textsize(text)
+            left, top, right, bottom = draw.textbbox((0, 0), text)
+            tw, th = right - left, bottom - top
             draw.rectangle(
                 [(xmin + 1, ymin - th), (xmin + tw + 1, ymin)], fill='green')
             draw.text((xmin + 1, ymin - th), text, fill=(255, 255, 255))


### PR DESCRIPTION
## Summary
Fix `DebugVisibleImage` in `rtdetr_paddle` for Pillow 10 compatibility.

`ImageDraw.textsize()` was removed in Pillow 10, so debug visualization can fail with:
`AttributeError: 'ImageDraw' object has no attribute 'textsize'`.

## Change
Use `ImageDraw.textbbox()` to compute label text size, matching the existing approach in `ppdet/utils/visualizer.py`.

## Verification
- Reproduced that `draw.textsize()` fails with Pillow 10.2.0
- Verified `draw.textbbox()` works with Pillow 10.2.0
- Ran `python3 -m compileall -q rtdetr_paddle/ppdet/data/transform/operators.py`
- Ran `git diff --check`
