### PR TITLE
Add RT-DETR v2 segmentation support

### DIFF
--- a/rtdetrv2_pytorch/configs/mask_rtdetrv2/include/dataloader.yml
+++ b/rtdetrv2_pytorch/configs/mask_rtdetrv2/include/dataloader.yml
@@ -1,0 +1,45 @@
+evaluator:
+  type: CocoEvaluator
+  iou_types: ['bbox', 'segm']
+
+
+train_dataloader:
+  dataset:
+    return_masks: True
+    transforms:
+      ops:
+        - {type: RandomPhotometricDistort, p: 0.5}
+        - {type: RandomZoomOut, fill: 0}
+        - {type: RandomIoUCrop, p: 0.8}
+        - {type: SanitizeBoundingBoxes, min_size: 1}
+        - {type: RandomHorizontalFlip}
+        - {type: Resize, size: [640, 640], }
+        - {type: SanitizeBoundingBoxes, min_size: 1}
+        - {type: ConvertPILImage, dtype: 'float32', scale: True}
+        - {type: ConvertBoxes, fmt: 'cxcywh', normalize: True}
+      policy:
+        name: stop_epoch
+        epoch: 71
+        ops: ['RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop']
+
+  collate_fn:
+    type: BatchImageCollateFunction
+    scales: [480, 512, 544, 576, 608, 640, 640, 640, 672, 704, 736, 768, 800]
+    stop_epoch: 71
+
+  shuffle: True
+  total_batch_size: 16
+  num_workers: 4
+
+
+val_dataloader:
+  dataset:
+    return_masks: True
+    transforms:
+      ops:
+        - {type: Resize, size: [640, 640]}
+        - {type: ConvertPILImage, dtype: 'float32', scale: True}
+  shuffle: False
+  total_batch_size: 32
+  num_workers: 4
+

--- a/rtdetrv2_pytorch/configs/mask_rtdetrv2/include/mask_rtdetrv2_r50vd.yml
+++ b/rtdetrv2_pytorch/configs/mask_rtdetrv2/include/mask_rtdetrv2_r50vd.yml
@@ -1,0 +1,93 @@
+task: detection
+
+model: RTDETR
+criterion: RTDETRCriterionv2
+postprocessor: RTDETRPostProcessor
+
+
+use_focal_loss: True
+eval_spatial_size: [640, 640] # h w
+
+
+RTDETR:
+  backbone: PResNet
+  encoder: MaskHybridEncoder
+  decoder: MaskRTDETRTransformerv2
+
+
+PResNet:
+  depth: 50
+  variant: d
+  freeze_at: 0
+  return_idx: [0, 1, 2, 3]
+  num_stages: 4
+  freeze_norm: True
+  pretrained: True
+
+
+MaskHybridEncoder:
+  in_channels: [256, 512, 1024, 2048]
+  feat_strides: [4, 8, 16, 32]
+
+  # intra
+  hidden_dim: 256
+  use_encoder_idx: [3]
+  num_encoder_layers: 1
+  nhead: 8
+  dim_feedforward: 1024
+  dropout: 0.
+  enc_act: 'gelu'
+
+  # cross
+  expansion: 1.0
+  depth_mult: 1
+  act: 'silu'
+
+  # masks
+  mask_feat_channels: [64, 64]
+  num_prototypes: 32
+
+
+MaskRTDETRTransformerv2:
+  feat_channels: [256, 256, 256]
+  feat_strides: [8, 16, 32]
+  hidden_dim: 256
+  num_levels: 3
+
+  num_layers: 6
+  num_queries: 300
+
+  num_denoising: 100
+  label_noise_ratio: 0.5
+  box_noise_scale: 1.0
+
+  eval_idx: -1
+
+  num_points: [4, 4, 4]
+  cross_attn_method: default
+  query_select_method: default
+
+  num_prototypes: 32
+  mask_enhanced: True
+
+
+RTDETRPostProcessor:
+  num_top_queries: 100
+  mask_threshold: 0.5
+
+
+RTDETRCriterionv2:
+  weight_dict: {loss_vfl: 1, loss_bbox: 5, loss_giou: 2, loss_mask: 5, loss_dice: 5}
+  losses: ['vfl', 'boxes', 'masks']
+  alpha: 0.75
+  gamma: 2.0
+  num_sample_points: 12544
+  oversample_ratio: 3.0
+  important_sample_ratio: 0.75
+
+  matcher:
+    type: HungarianMatcher
+    weight_dict: {cost_class: 4, cost_bbox: 5, cost_giou: 2, cost_mask: 5, cost_dice: 5}
+    alpha: 0.25
+    gamma: 2.0
+    num_sample_points: 12544

--- a/rtdetrv2_pytorch/configs/mask_rtdetrv2/mask_rtdetrv2_r50vd_6x_coco.yml
+++ b/rtdetrv2_pytorch/configs/mask_rtdetrv2/mask_rtdetrv2_r50vd_6x_coco.yml
@@ -1,0 +1,26 @@
+__include__: [
+  '../dataset/coco_detection.yml',
+  '../runtime.yml',
+  './include/dataloader.yml',
+  '../rtdetrv2/include/optimizer.yml',
+  './include/mask_rtdetrv2_r50vd.yml',
+]
+
+
+output_dir: ./output/mask_rtdetrv2_r50vd_6x_coco
+
+
+optimizer:
+  type: AdamW
+  params:
+    -
+      params: '^(?=.*backbone)(?!.*norm).*$'
+      lr: 0.00001
+    -
+      params: '^(?=.*(?:encoder|decoder))(?=.*(?:norm|bn)).*$'
+      weight_decay: 0.
+
+  lr: 0.0001
+  betas: [0.9, 0.999]
+  weight_decay: 0.0001
+

--- a/rtdetrv2_pytorch/src/data/dataloader.py
+++ b/rtdetrv2_pytorch/src/data/dataloader.py
@@ -100,8 +100,6 @@ class BatchImageCollateFunction(BaseCollateFunction):
             images = F.interpolate(images, size=sz)
             if 'masks' in targets[0]:
                 for tg in targets:
-                    tg['masks'] = F.interpolate(tg['masks'], size=sz, mode='nearest')
-                raise NotImplementedError('')
+                    tg['masks'] = F.interpolate(tg['masks'][:, None].float(), size=sz, mode='nearest')[:, 0] > 0.5
 
         return images, targets
-

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/__init__.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/__init__.py
@@ -4,11 +4,11 @@
 
 from .rtdetr import RTDETR
 from .matcher import HungarianMatcher
-from .hybrid_encoder import HybridEncoder
+from .hybrid_encoder import HybridEncoder, MaskHybridEncoder
 from .rtdetr_decoder import RTDETRTransformer
 from .rtdetr_criterion import RTDETRCriterion
 from .rtdetr_postprocessor import RTDETRPostProcessor
 
 # v2
-from .rtdetrv2_decoder import RTDETRTransformerv2
+from .rtdetrv2_decoder import RTDETRTransformerv2, MaskRTDETRTransformerv2
 from .rtdetrv2_criterion import RTDETRCriterionv2

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/box_ops.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/box_ops.py
@@ -75,9 +75,9 @@ def masks_to_boxes(masks):
 
     h, w = masks.shape[-2:]
 
-    y = torch.arange(0, h, dtype=torch.float)
-    x = torch.arange(0, w, dtype=torch.float)
-    y, x = torch.meshgrid(y, x)
+    y = torch.arange(0, h, dtype=torch.float32, device=masks.device)
+    x = torch.arange(0, w, dtype=torch.float32, device=masks.device)
+    y, x = torch.meshgrid(y, x, indexing='ij')
 
     x_mask = (masks * x.unsqueeze(0))
     x_max = x_mask.flatten(1).max(-1)[0]

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -2,6 +2,7 @@
 """
 
 import copy
+import math
 from collections import OrderedDict
 
 import torch 
@@ -13,7 +14,7 @@ from .utils import get_activation
 from ...core import register
 
 
-__all__ = ['HybridEncoder']
+__all__ = ['HybridEncoder', 'MaskHybridEncoder']
 
 
 
@@ -328,3 +329,147 @@ class HybridEncoder(nn.Module):
             outs.append(out)
 
         return outs
+
+
+class MaskFeatFPN(nn.Module):
+    def __init__(
+        self,
+        in_channels=[256, 256, 256],
+        fpn_strides=[8, 16, 32],
+        feat_channels=256,
+        dropout_ratio=0.0,
+        out_channels=256,
+        align_corners=False,
+        act='silu',
+    ):
+        super().__init__()
+        assert len(in_channels) == len(fpn_strides)
+
+        reorder_index = sorted(range(len(fpn_strides)), key=lambda i: fpn_strides[i])
+        in_channels = [in_channels[i] for i in reorder_index]
+        fpn_strides = [fpn_strides[i] for i in reorder_index]
+        assert min(fpn_strides) == fpn_strides[0]
+
+        self.reorder_index = reorder_index
+        self.fpn_strides = fpn_strides
+        self.dropout_ratio = dropout_ratio
+        self.align_corners = align_corners
+        if self.dropout_ratio > 0:
+            self.dropout = nn.Dropout2d(dropout_ratio)
+
+        self.scale_heads = nn.ModuleList()
+        base_stride = fpn_strides[0]
+        for i, stride in enumerate(fpn_strides):
+            head_length = max(1, int(math.log2(stride) - math.log2(base_stride)))
+            scale_head = []
+            for k in range(head_length):
+                in_c = in_channels[i] if k == 0 else feat_channels
+                scale_head.append(ConvNormLayer(in_c, feat_channels, 3, 1, act=act))
+                if stride != base_stride:
+                    scale_head.append(
+                        nn.Upsample(scale_factor=2, mode='bilinear', align_corners=align_corners)
+                    )
+            self.scale_heads.append(nn.Sequential(*scale_head))
+
+        self.output_conv = ConvNormLayer(feat_channels, out_channels, 3, 1, act=act)
+
+    def forward(self, inputs):
+        x = [inputs[i] for i in self.reorder_index]
+
+        output = self.scale_heads[0](x[0])
+        for i in range(1, len(self.fpn_strides)):
+            output = output + F.interpolate(
+                self.scale_heads[i](x[i]),
+                size=output.shape[-2:],
+                mode='bilinear',
+                align_corners=self.align_corners,
+            )
+
+        if self.dropout_ratio > 0:
+            output = self.dropout(output)
+
+        return self.output_conv(output)
+
+
+@register()
+class MaskHybridEncoder(HybridEncoder):
+    __share__ = ['eval_spatial_size', ]
+
+    def __init__(
+        self,
+        in_channels=[256, 512, 1024, 2048],
+        feat_strides=[4, 8, 16, 32],
+        hidden_dim=256,
+        nhead=8,
+        dim_feedforward=1024,
+        dropout=0.0,
+        enc_act='gelu',
+        use_encoder_idx=[3],
+        num_encoder_layers=1,
+        pe_temperature=10000,
+        expansion=1.0,
+        depth_mult=1.0,
+        mask_feat_channels=[64, 64],
+        num_prototypes=32,
+        act='silu',
+        eval_spatial_size=None,
+        version='v2',
+    ):
+        in_channels = list(in_channels)
+        feat_strides = list(feat_strides)
+        use_encoder_idx = [idx - 1 for idx in use_encoder_idx]
+
+        assert len(in_channels) == len(feat_strides)
+        assert len(in_channels) >= 2
+        assert feat_strides[0] == 4
+
+        x4_in_channels = in_channels[0]
+        super().__init__(
+            in_channels=in_channels[1:],
+            feat_strides=feat_strides[1:],
+            hidden_dim=hidden_dim,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            enc_act=enc_act,
+            use_encoder_idx=use_encoder_idx,
+            num_encoder_layers=num_encoder_layers,
+            pe_temperature=pe_temperature,
+            expansion=expansion,
+            depth_mult=depth_mult,
+            act=act,
+            eval_spatial_size=eval_spatial_size,
+            version=version,
+        )
+
+        self.mask_feat_head = MaskFeatFPN(
+            [hidden_dim] * len(self.feat_strides),
+            self.feat_strides,
+            feat_channels=mask_feat_channels[0],
+            out_channels=mask_feat_channels[1],
+            act=act,
+        )
+        self.enc_mask_lateral = ConvNormLayer(x4_in_channels, mask_feat_channels[1], 3, 1, act=act)
+        self.enc_mask_output = nn.Sequential(
+            ConvNormLayer(mask_feat_channels[1], mask_feat_channels[1], 3, 1, act=act),
+            nn.Conv2d(mask_feat_channels[1], num_prototypes, 1),
+        )
+        self.mask_out_stride = feat_strides[0]
+
+    def forward(self, feats):
+        assert len(feats) == len(self.in_channels) + 1
+
+        x4_feat = feats[0]
+        enc_feats = super().forward(feats[1:])
+
+        mask_feat = self.mask_feat_head(enc_feats)
+        mask_feat = F.interpolate(
+            mask_feat,
+            size=x4_feat.shape[-2:],
+            mode='bilinear',
+            align_corners=False,
+        )
+        mask_feat = mask_feat + self.enc_mask_lateral(x4_feat)
+        mask_feat = self.enc_mask_output(mask_feat)
+
+        return enc_feats, mask_feat

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/matcher.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/matcher.py
@@ -17,6 +17,23 @@ from .box_ops import box_cxcywh_to_xyxy, generalized_box_iou
 from ...core import register
 
 
+def batch_sigmoid_ce_loss(inputs: torch.Tensor, targets: torch.Tensor):
+    hw = inputs.shape[1]
+
+    pos = F.binary_cross_entropy_with_logits(inputs, torch.ones_like(inputs), reduction='none')
+    neg = F.binary_cross_entropy_with_logits(inputs, torch.zeros_like(inputs), reduction='none')
+
+    loss = torch.einsum('nc,mc->nm', pos, targets) + torch.einsum('nc,mc->nm', neg, (1 - targets))
+    return loss / hw
+
+
+def batch_dice_loss(inputs: torch.Tensor, targets: torch.Tensor):
+    inputs = inputs.sigmoid()
+    numerator = 2 * torch.einsum('nc,mc->nm', inputs, targets)
+    denominator = inputs.sum(-1)[:, None] + targets.sum(-1)[None, :]
+    return 1 - (numerator + 1) / (denominator + 1)
+
+
 @register()
 class HungarianMatcher(nn.Module):
     """This class computes an assignment between the targets and the predictions of the network
@@ -28,7 +45,7 @@ class HungarianMatcher(nn.Module):
 
     __share__ = ['use_focal_loss', ]
 
-    def __init__(self, weight_dict, use_focal_loss=False, alpha=0.25, gamma=2.0):
+    def __init__(self, weight_dict, use_focal_loss=False, alpha=0.25, gamma=2.0, num_sample_points=12544):
         """Creates the matcher
 
         Params:
@@ -40,12 +57,40 @@ class HungarianMatcher(nn.Module):
         self.cost_class = weight_dict['cost_class']
         self.cost_bbox = weight_dict['cost_bbox']
         self.cost_giou = weight_dict['cost_giou']
+        self.cost_mask = weight_dict.get('cost_mask', 0)
+        self.cost_dice = weight_dict.get('cost_dice', 0)
 
         self.use_focal_loss = use_focal_loss
         self.alpha = alpha
         self.gamma = gamma
+        self.num_sample_points = num_sample_points
 
-        assert self.cost_class != 0 or self.cost_bbox != 0 or self.cost_giou != 0, "all costs cant be 0"
+        assert self.cost_class != 0 or self.cost_bbox != 0 or self.cost_giou != 0 \
+            or self.cost_mask != 0 or self.cost_dice != 0, "all costs cant be 0"
+
+    def _compute_mask_cost(self, out_mask, tgt_mask):
+        if out_mask.numel() == 0 or tgt_mask.numel() == 0:
+            return out_mask.new_zeros((out_mask.shape[0], tgt_mask.shape[0]))
+
+        point_coords = torch.rand(1, self.num_sample_points, 2, device=out_mask.device)
+        point_coords = 2.0 * point_coords.unsqueeze(1) - 1.0
+
+        out_mask = F.grid_sample(
+            out_mask[:, None],
+            point_coords.repeat(out_mask.shape[0], 1, 1, 1),
+            align_corners=False,
+        ).squeeze(1).squeeze(1)
+
+        tgt_mask = F.grid_sample(
+            tgt_mask[:, None].to(out_mask.dtype),
+            point_coords.repeat(tgt_mask.shape[0], 1, 1, 1),
+            align_corners=False,
+        ).squeeze(1).squeeze(1)
+
+        return (
+            self.cost_mask * batch_sigmoid_ce_loss(out_mask, tgt_mask)
+            + self.cost_dice * batch_dice_loss(out_mask, tgt_mask)
+        )
 
     @torch.no_grad()
     def forward(self, outputs: Dict[str, torch.Tensor], targets):
@@ -101,10 +146,18 @@ class HungarianMatcher(nn.Module):
         
         # Final cost matrix
         C = self.cost_bbox * cost_bbox + self.cost_class * cost_class + self.cost_giou * cost_giou
-        C = C.view(bs, num_queries, -1).cpu()
+        C = C.view(bs, num_queries, -1)
 
         sizes = [len(v["boxes"]) for v in targets]
-        indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))]
+        cost_chunks = C.split(sizes, -1)
+        cost_matrices = []
+        for i, c in enumerate(cost_chunks):
+            cost = c[i]
+            if (self.cost_mask != 0 or self.cost_dice != 0) and 'pred_masks' in outputs and 'masks' in targets[i]:
+                cost = cost + self._compute_mask_cost(outputs['pred_masks'][i], targets[i]['masks'])
+            cost_matrices.append(cost.cpu())
+
+        indices = [linear_sum_assignment(c) for c in cost_matrices]
         indices = [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
 
         return {'indices': indices}

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
@@ -32,13 +32,15 @@ class RTDETRPostProcessor(nn.Module):
         num_classes=80, 
         use_focal_loss=True, 
         num_top_queries=300, 
-        remap_mscoco_category=False
+        remap_mscoco_category=False,
+        mask_threshold=0.5,
     ) -> None:
         super().__init__()
         self.use_focal_loss = use_focal_loss
         self.num_top_queries = num_top_queries
         self.num_classes = int(num_classes)
         self.remap_mscoco_category = remap_mscoco_category 
+        self.mask_threshold = mask_threshold
         self.deploy_mode = False 
 
     def extra_repr(self) -> str:
@@ -47,6 +49,7 @@ class RTDETRPostProcessor(nn.Module):
     # def forward(self, outputs, orig_target_sizes):
     def forward(self, outputs, orig_target_sizes: torch.Tensor):
         logits, boxes = outputs['pred_logits'], outputs['pred_boxes']
+        pred_masks = outputs.get('pred_masks', None)
         # orig_target_sizes = torch.stack([t["orig_size"] for t in targets], dim=0)        
 
         bbox_pred = torchvision.ops.box_convert(boxes, in_fmt='cxcywh', out_fmt='xyxy')
@@ -60,18 +63,30 @@ class RTDETRPostProcessor(nn.Module):
             labels = mod(index, self.num_classes)
             index = index // self.num_classes
             boxes = bbox_pred.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, bbox_pred.shape[-1]))
+            query_index = index
             
         else:
             scores = F.softmax(logits, dim=-1)[:, :, :-1]
             scores, labels = scores.max(dim=-1)
             boxes = bbox_pred
+            query_index = torch.arange(boxes.shape[1], device=boxes.device).unsqueeze(0).tile([boxes.shape[0], 1])
             if scores.shape[1] > self.num_top_queries:
                 scores, index = torch.topk(scores, self.num_top_queries, dim=-1)
                 labels = torch.gather(labels, dim=1, index=index)
                 boxes = torch.gather(boxes, dim=1, index=index.unsqueeze(-1).tile(1, 1, boxes.shape[-1]))
+                query_index = index
+
+        masks = None
+        if pred_masks is not None:
+            masks = pred_masks.gather(
+                dim=1,
+                index=query_index.unsqueeze(-1).unsqueeze(-1).repeat(1, 1, pred_masks.shape[-2], pred_masks.shape[-1]),
+            )
         
         # TODO for onnx export
         if self.deploy_mode:
+            if masks is not None:
+                return labels, boxes, scores, masks
             return labels, boxes, scores
 
         # TODO
@@ -80,9 +95,24 @@ class RTDETRPostProcessor(nn.Module):
             labels = torch.tensor([mscoco_label2category[int(x.item())] for x in labels.flatten()])\
                 .to(boxes.device).reshape(labels.shape)
 
+        if masks is not None:
+            processed_masks = []
+            for img_masks, target_size in zip(masks, orig_target_sizes):
+                target_w, target_h = target_size.unbind(0)
+                img_masks = F.interpolate(
+                    img_masks.unsqueeze(1),
+                    size=(int(target_h.item()), int(target_w.item())),
+                    mode='bilinear',
+                    align_corners=False,
+                ).squeeze(1)
+                processed_masks.append((img_masks.sigmoid() > self.mask_threshold).unsqueeze(1))
+            masks = processed_masks
+
         results = []
-        for lab, box, sco in zip(labels, boxes, scores):
+        for i, (lab, box, sco) in enumerate(zip(labels, boxes, scores)):
             result = dict(labels=lab, boxes=box, scores=sco)
+            if masks is not None:
+                result['masks'] = masks[i]
             results.append(result)
         
         return results

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_criterion.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_criterion.py
@@ -32,7 +32,10 @@ class RTDETRCriterionv2(nn.Module):
         gamma=2.0, 
         num_classes=80, 
         boxes_weight_format=None,
-        share_matched_indices=False):
+        share_matched_indices=False,
+        num_sample_points=12544,
+        oversample_ratio=3.0,
+        important_sample_ratio=0.75):
         """Create the criterion.
         Parameters:
             matcher: module able to compute a matching between targets and proposals
@@ -51,6 +54,14 @@ class RTDETRCriterionv2(nn.Module):
         self.share_matched_indices = share_matched_indices
         self.alpha = alpha
         self.gamma = gamma
+        assert oversample_ratio >= 1
+        assert 0 <= important_sample_ratio <= 1
+        self.num_sample_points = num_sample_points
+        self.oversample_ratio = oversample_ratio
+        self.important_sample_ratio = important_sample_ratio
+        self.num_oversample_points = int(num_sample_points * oversample_ratio)
+        self.num_important_points = int(num_sample_points * important_sample_ratio)
+        self.num_random_points = num_sample_points - self.num_important_points
 
     def loss_labels_focal(self, outputs, targets, indices, num_boxes):
         assert 'pred_logits' in outputs
@@ -115,6 +126,80 @@ class RTDETRCriterionv2(nn.Module):
         losses['loss_giou'] = loss_giou.sum() / num_boxes
         return losses
 
+    def loss_masks(self, outputs, targets, indices, num_boxes):
+        assert 'pred_masks' in outputs
+        assert 'masks' in targets[0]
+
+        src_idx = self._get_src_permutation_idx(indices)
+        src_masks = outputs['pred_masks'][src_idx]
+
+        target_masks = torch.cat([t['masks'][j] for t, (_, j) in zip(targets, indices)], dim=0)
+        target_masks = target_masks.to(device=src_masks.device, dtype=src_masks.dtype)
+
+        if src_masks.shape[0] == 0:
+            zero = outputs['pred_masks'].sum() * 0.0
+            return {'loss_mask': zero, 'loss_dice': zero}
+
+        point_coords = self._get_point_coords_by_uncertainty(src_masks)
+        point_grid = 2.0 * point_coords.unsqueeze(1) - 1.0
+
+        src_masks = F.grid_sample(
+            src_masks.unsqueeze(1),
+            point_grid,
+            align_corners=False,
+        ).squeeze(1).squeeze(1)
+
+        target_masks = F.grid_sample(
+            target_masks.unsqueeze(1),
+            point_grid,
+            align_corners=False,
+        ).squeeze(1).squeeze(1).detach()
+
+        loss_mask = F.binary_cross_entropy_with_logits(src_masks, target_masks, reduction='none')
+        loss_mask = loss_mask.mean(1).sum() / num_boxes
+        loss_dice = self._dice_loss(src_masks, target_masks, num_boxes)
+
+        return {'loss_mask': loss_mask, 'loss_dice': loss_dice}
+
+    def _dice_loss(self, inputs, targets, num_boxes):
+        inputs = inputs.sigmoid()
+        inputs = inputs.flatten(1)
+        targets = targets.flatten(1)
+        numerator = 2 * (inputs * targets).sum(1)
+        denominator = inputs.sum(-1) + targets.sum(-1)
+        loss = 1 - (numerator + 1) / (denominator + 1)
+        return loss.sum() / num_boxes
+
+    @torch.no_grad()
+    def _get_point_coords_by_uncertainty(self, masks):
+        masks = masks.detach()
+        num_masks = masks.shape[0]
+        point_coords = torch.rand(num_masks, self.num_oversample_points, 2, device=masks.device)
+
+        point_logits = F.grid_sample(
+            masks.unsqueeze(1),
+            2.0 * point_coords.unsqueeze(1) - 1.0,
+            align_corners=False,
+        ).squeeze(1).squeeze(1)
+        point_uncertainties = -point_logits.abs()
+
+        topk_idx = torch.topk(point_uncertainties, self.num_important_points, dim=1).indices
+        shift = self.num_oversample_points * torch.arange(num_masks, dtype=torch.long, device=masks.device)
+        topk_idx = topk_idx + shift[:, None]
+        point_coords = point_coords.reshape(-1, 2)[topk_idx.reshape(-1)]
+        point_coords = point_coords.reshape(num_masks, self.num_important_points, 2)
+
+        if self.num_random_points > 0:
+            point_coords = torch.cat(
+                [
+                    point_coords,
+                    torch.rand(num_masks, self.num_random_points, 2, device=masks.device),
+                ],
+                dim=1,
+            )
+
+        return point_coords
+
     def _get_src_permutation_idx(self, indices):
         # permute predictions following indices
         batch_idx = torch.cat([torch.full_like(src, i) for i, (src, _) in enumerate(indices)])
@@ -132,6 +217,7 @@ class RTDETRCriterionv2(nn.Module):
             'boxes': self.loss_boxes,
             'focal': self.loss_labels_focal,
             'vfl': self.loss_labels_vfl,
+            'masks': self.loss_masks,
         }
         assert loss in loss_map, f'do you really want to compute {loss} loss?'
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_decoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_decoder.py
@@ -13,12 +13,13 @@ import torch.nn.init as init
 from typing import List
 
 from .denoising import get_contrastive_denoising_training_group
+from .box_ops import box_xyxy_to_cxcywh, masks_to_boxes
 from .utils import deformable_attention_core_func_v2, get_activation, inverse_sigmoid
 from .utils import bias_init_with_prob
 
 from ...core import register
 
-__all__ = ['RTDETRTransformerv2']
+__all__ = ['RTDETRTransformerv2', 'MaskRTDETRTransformerv2']
 
 
 class MLP(nn.Module):
@@ -262,7 +263,15 @@ class TransformerDecoder(nn.Module):
             ref_points_input = ref_points_detach.unsqueeze(2)
             query_pos_embed = query_pos_head(ref_points_detach)
 
-            output = layer(output, ref_points_input, memory, memory_spatial_shapes, attn_mask, memory_mask, query_pos_embed)
+            output = layer(
+                output,
+                ref_points_input,
+                memory,
+                memory_spatial_shapes,
+                attn_mask,
+                memory_mask,
+                query_pos_embed,
+            )
 
             inter_ref_bbox = F.sigmoid(bbox_head[i](output) + inverse_sigmoid(ref_points_detach))
 
@@ -282,6 +291,109 @@ class TransformerDecoder(nn.Module):
             ref_points_detach = inter_ref_bbox.detach()
 
         return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits)
+
+
+def _get_pred_mask(query_embed, mask_feat, dec_norm, mask_query_head):
+    out_query = dec_norm(query_embed)
+    mask_query_embed = mask_query_head(out_query)
+    bs, num_queries, _ = mask_query_embed.shape
+    _, _, mask_h, mask_w = mask_feat.shape
+    out_mask = torch.bmm(mask_query_embed, mask_feat.flatten(2))
+    return out_mask.reshape(bs, num_queries, mask_h, mask_w)
+
+
+def _get_pred_class_and_mask(query_embed, mask_feat, dec_norm, score_head, mask_query_head):
+    out_query = dec_norm(query_embed)
+    out_logits = score_head(out_query)
+    mask_query_embed = mask_query_head(out_query)
+    bs, num_queries, _ = mask_query_embed.shape
+    _, _, mask_h, mask_w = mask_feat.shape
+    out_mask = torch.bmm(mask_query_embed, mask_feat.flatten(2))
+    return out_logits, out_mask.reshape(bs, num_queries, mask_h, mask_w)
+
+
+def _mask_to_box_coordinate(masks, fallback_boxes=None):
+    bs, num_queries, h, w = masks.shape
+    flat_masks = masks.flatten(0, 1)
+    empty = flat_masks.flatten(1).sum(-1) == 0
+
+    boxes = masks_to_boxes(flat_masks)
+    boxes = boxes / torch.tensor([w, h, w, h], dtype=boxes.dtype, device=boxes.device)
+    boxes = box_xyxy_to_cxcywh(boxes).reshape(bs, num_queries, 4)
+    boxes = boxes.clamp(min=0.0, max=1.0)
+
+    empty = empty.reshape(bs, num_queries)
+    if fallback_boxes is not None:
+        boxes = torch.where(empty.unsqueeze(-1), fallback_boxes, boxes)
+
+    return boxes, empty
+
+
+class MaskTransformerDecoder(nn.Module):
+    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1):
+        super(MaskTransformerDecoder, self).__init__()
+        self.layers = nn.ModuleList([copy.deepcopy(decoder_layer) for _ in range(num_layers)])
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+
+    def forward(
+        self,
+        target,
+        ref_points_unact,
+        memory,
+        memory_spatial_shapes,
+        mask_feat,
+        bbox_head,
+        score_head,
+        query_pos_head,
+        mask_query_head,
+        dec_norm,
+        attn_mask=None,
+        memory_mask=None,
+    ):
+        dec_out_bboxes = []
+        dec_out_logits = []
+        dec_out_masks = []
+        ref_points_detach = F.sigmoid(ref_points_unact)
+
+        output = target
+        for i, layer in enumerate(self.layers):
+            ref_points_input = ref_points_detach.unsqueeze(2)
+            query_pos_embed = query_pos_head(ref_points_detach)
+
+            output = layer(
+                output,
+                ref_points_input,
+                memory,
+                memory_spatial_shapes,
+                attn_mask,
+                memory_mask,
+                query_pos_embed,
+            )
+
+            inter_ref_bbox = F.sigmoid(bbox_head[i](output) + inverse_sigmoid(ref_points_detach))
+
+            if self.training:
+                logits, masks = _get_pred_class_and_mask(output, mask_feat, dec_norm, score_head[i], mask_query_head)
+                dec_out_logits.append(logits)
+                dec_out_masks.append(masks)
+                if i == 0:
+                    dec_out_bboxes.append(inter_ref_bbox)
+                else:
+                    dec_out_bboxes.append(F.sigmoid(bbox_head[i](output) + inverse_sigmoid(ref_points)))
+
+            elif i == self.eval_idx:
+                logits, masks = _get_pred_class_and_mask(output, mask_feat, dec_norm, score_head[i], mask_query_head)
+                dec_out_logits.append(logits)
+                dec_out_masks.append(masks)
+                dec_out_bboxes.append(inter_ref_bbox)
+                break
+
+            ref_points = inter_ref_bbox
+            ref_points_detach = inter_ref_bbox.detach()
+
+        return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits), torch.stack(dec_out_masks)
 
 
 @register()
@@ -607,3 +719,197 @@ class RTDETRTransformerv2(nn.Module):
         # as a dict having both a Tensor and a list.
         return [{'pred_logits': a, 'pred_boxes': b}
                 for a, b in zip(outputs_class, outputs_coord)]
+
+
+@register()
+class MaskRTDETRTransformerv2(RTDETRTransformerv2):
+    __share__ = ['num_classes', 'eval_spatial_size']
+
+    def __init__(
+        self,
+        num_classes=80,
+        hidden_dim=256,
+        num_queries=300,
+        feat_channels=[512, 1024, 2048],
+        feat_strides=[8, 16, 32],
+        num_levels=3,
+        num_points=4,
+        nhead=8,
+        num_layers=6,
+        dim_feedforward=1024,
+        dropout=0.,
+        activation="relu",
+        num_denoising=100,
+        label_noise_ratio=0.5,
+        box_noise_scale=1.0,
+        learn_query_content=False,
+        eval_spatial_size=None,
+        eval_idx=-1,
+        eps=1e-2,
+        aux_loss=True,
+        cross_attn_method='default',
+        query_select_method='default',
+        num_prototypes=32,
+        mask_enhanced=True,
+    ):
+        super().__init__(
+            num_classes=num_classes,
+            hidden_dim=hidden_dim,
+            num_queries=num_queries,
+            feat_channels=feat_channels,
+            feat_strides=list(feat_strides),
+            num_levels=num_levels,
+            num_points=num_points,
+            nhead=nhead,
+            num_layers=num_layers,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            activation=activation,
+            num_denoising=num_denoising,
+            label_noise_ratio=label_noise_ratio,
+            box_noise_scale=box_noise_scale,
+            learn_query_content=learn_query_content,
+            eval_spatial_size=eval_spatial_size,
+            eval_idx=eval_idx,
+            eps=eps,
+            aux_loss=aux_loss,
+            cross_attn_method=cross_attn_method,
+            query_select_method=query_select_method,
+        )
+
+        decoder_layer = TransformerDecoderLayer(
+            hidden_dim,
+            nhead,
+            dim_feedforward,
+            dropout,
+            activation,
+            num_levels,
+            num_points,
+            cross_attn_method=cross_attn_method,
+        )
+        self.decoder = MaskTransformerDecoder(hidden_dim, decoder_layer, num_layers, eval_idx)
+
+        self.num_prototypes = num_prototypes
+        self.mask_enhanced = mask_enhanced
+        self.mask_query_head = MLP(hidden_dim, hidden_dim, num_prototypes, 3)
+        self.dec_norm = nn.LayerNorm(hidden_dim)
+
+    def _get_decoder_input(
+        self,
+        memory: torch.Tensor,
+        mask_feat: torch.Tensor,
+        spatial_shapes,
+        denoising_logits=None,
+        denoising_bbox_unact=None,
+    ):
+        # prepare input for decoder
+        if self.training or self.eval_spatial_size is None:
+            anchors, valid_mask = self._generate_anchors(spatial_shapes, device=memory.device)
+        else:
+            anchors = self.anchors
+            valid_mask = self.valid_mask
+
+        memory = valid_mask.to(memory.dtype) * memory
+
+        output_memory: torch.Tensor = self.enc_output(memory)
+        enc_outputs_logits: torch.Tensor = self.enc_score_head(output_memory)
+        enc_outputs_coord_unact: torch.Tensor = self.enc_bbox_head(output_memory) + anchors
+
+        enc_topk_bboxes_list, enc_topk_logits_list, enc_topk_masks_list = [], [], []
+        enc_topk_memory, enc_topk_logits, enc_topk_bbox_unact = \
+            self._select_topk(output_memory, enc_outputs_logits, enc_outputs_coord_unact, self.num_queries)
+
+        enc_topk_masks = _get_pred_mask(enc_topk_memory, mask_feat, self.dec_norm, self.mask_query_head)
+        enc_topk_bboxes = F.sigmoid(enc_topk_bbox_unact)
+
+        if self.training:
+            enc_topk_bboxes_list.append(enc_topk_bboxes)
+            enc_topk_logits_list.append(enc_topk_logits)
+            enc_topk_masks_list.append(enc_topk_masks)
+
+        if self.learn_query_content:
+            content = self.tgt_embed.weight.unsqueeze(0).tile([memory.shape[0], 1, 1])
+        else:
+            content = enc_topk_memory.detach()
+
+        if self.mask_enhanced:
+            mask_ref_points, _ = _mask_to_box_coordinate(enc_topk_masks > 0, fallback_boxes=enc_topk_bboxes)
+            enc_topk_bbox_unact = inverse_sigmoid(mask_ref_points)
+
+        enc_topk_bbox_unact = enc_topk_bbox_unact.detach()
+
+        if denoising_bbox_unact is not None:
+            enc_topk_bbox_unact = torch.concat([denoising_bbox_unact, enc_topk_bbox_unact], dim=1)
+            content = torch.concat([denoising_logits, content], dim=1)
+
+        return content, enc_topk_bbox_unact, enc_topk_bboxes_list, enc_topk_logits_list, enc_topk_masks_list
+
+    def forward(self, feats, targets=None):
+        if not isinstance(feats, (list, tuple)) or len(feats) != 2:
+            raise ValueError('MaskRTDETRTransformerv2 expects encoder output as (encoded_feats, mask_feat).')
+
+        enc_feats, mask_feat = feats
+
+        # input projection and embedding
+        memory, spatial_shapes = self._get_encoder_input(enc_feats)
+
+        # prepare denoising training
+        if self.training and self.num_denoising > 0:
+            denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = \
+                get_contrastive_denoising_training_group(targets, \
+                    self.num_classes,
+                    self.num_queries,
+                    self.denoising_class_embed,
+                    num_denoising=self.num_denoising,
+                    label_noise_ratio=self.label_noise_ratio,
+                    box_noise_scale=self.box_noise_scale, )
+        else:
+            denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = None, None, None, None
+
+        init_ref_contents, init_ref_points_unact, enc_topk_bboxes_list, enc_topk_logits_list, enc_topk_masks_list = \
+            self._get_decoder_input(memory, mask_feat, spatial_shapes, denoising_logits, denoising_bbox_unact)
+
+        # decoder
+        out_bboxes, out_logits, out_masks = self.decoder(
+            init_ref_contents,
+            init_ref_points_unact,
+            memory,
+            spatial_shapes,
+            mask_feat,
+            self.dec_bbox_head,
+            self.dec_score_head,
+            self.query_pos_head,
+            self.mask_query_head,
+            self.dec_norm,
+            attn_mask=attn_mask)
+
+        if self.training and dn_meta is not None:
+            dn_out_bboxes, out_bboxes = torch.split(out_bboxes, dn_meta['dn_num_split'], dim=2)
+            dn_out_logits, out_logits = torch.split(out_logits, dn_meta['dn_num_split'], dim=2)
+            dn_out_masks, out_masks = torch.split(out_masks, dn_meta['dn_num_split'], dim=2)
+
+        out = {'pred_logits': out_logits[-1], 'pred_boxes': out_bboxes[-1], 'pred_masks': out_masks[-1]}
+
+        if self.training and self.aux_loss:
+            out['aux_outputs'] = self._set_aux_loss(out_logits[:-1], out_bboxes[:-1], out_masks[:-1])
+            out['enc_aux_outputs'] = self._set_aux_loss(
+                enc_topk_logits_list, enc_topk_bboxes_list, enc_topk_masks_list
+            )
+            out['enc_meta'] = {'class_agnostic': self.query_select_method == 'agnostic'}
+
+            if dn_meta is not None:
+                out['dn_aux_outputs'] = self._set_aux_loss(dn_out_logits, dn_out_bboxes, dn_out_masks)
+                out['dn_meta'] = dn_meta
+
+        return out
+
+    @torch.jit.unused
+    def _set_aux_loss(self, outputs_class, outputs_coord, outputs_masks=None):
+        # this is a workaround to make torchscript happy, as torchscript
+        # doesn't support dictionary with non-homogeneous values, such
+        # as a dict having both a Tensor and a list.
+        if outputs_masks is None:
+            return super()._set_aux_loss(outputs_class, outputs_coord)
+
+        return [{'pred_logits': a, 'pred_boxes': b, 'pred_masks': c}
+                for a, b, c in zip(outputs_class, outputs_coord, outputs_masks)]

--- a/rtdetrv2_pytorch/tools/evaluate_mask_rtdetrv2.py
+++ b/rtdetrv2_pytorch/tools/evaluate_mask_rtdetrv2.py
@@ -1,0 +1,187 @@
+"""Evaluate Mask RT-DETR v2 checkpoints on COCO-style instance segmentation data.
+
+This tool mirrors ``tools/train.py --test-only`` but also writes a compact
+metrics JSON file and can export COCO-format bbox/segm predictions.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from src.core import YAMLConfig, yaml_utils
+from src.misc import dist_utils
+from src.misc.logger import MetricLogger
+from src.solver import TASKS
+
+
+COCO_METRIC_NAMES = [
+    "AP",
+    "AP50",
+    "AP75",
+    "AP_small",
+    "AP_medium",
+    "AP_large",
+    "AR_1",
+    "AR_10",
+    "AR_100",
+    "AR_small",
+    "AR_medium",
+    "AR_large",
+]
+
+
+def _to_cpu(value: Any) -> Any:
+    if torch.is_tensor(value):
+        return value.detach().cpu()
+    if isinstance(value, dict):
+        return {key: _to_cpu(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_cpu(item) for item in value]
+    return value
+
+
+def _named_metrics(values):
+    return {name: float(value) for name, value in zip(COCO_METRIC_NAMES, values)}
+
+
+@torch.no_grad()
+def evaluate_and_collect(model, postprocessor, data_loader, coco_evaluator, device, save_predictions=False):
+    model.eval()
+    coco_evaluator.cleanup()
+
+    prediction_results = defaultdict(list)
+    metric_logger = MetricLogger(delimiter="  ")
+    header = "Test:"
+
+    for samples, targets in metric_logger.log_every(data_loader, 10, header):
+        samples = samples.to(device)
+        targets = [{key: value.to(device) for key, value in target.items()} for target in targets]
+
+        outputs = model(samples)
+        orig_target_sizes = torch.stack([target["orig_size"] for target in targets], dim=0)
+        results = postprocessor(outputs, orig_target_sizes)
+
+        res = {
+            target["image_id"].item(): _to_cpu(output)
+            for target, output in zip(targets, results)
+        }
+
+        if save_predictions:
+            for iou_type in coco_evaluator.iou_types:
+                prediction_results[iou_type].extend(coco_evaluator.prepare(res, iou_type))
+
+        coco_evaluator.update(res)
+
+    metric_logger.synchronize_between_processes()
+    print("Averaged stats:", metric_logger)
+    coco_evaluator.synchronize_between_processes()
+    coco_evaluator.accumulate()
+    coco_evaluator.summarize()
+
+    stats = {}
+    if "bbox" in coco_evaluator.iou_types:
+        stats["bbox"] = coco_evaluator.coco_eval["bbox"].stats.tolist()
+    if "segm" in coco_evaluator.iou_types:
+        stats["segm"] = coco_evaluator.coco_eval["segm"].stats.tolist()
+
+    if save_predictions:
+        gathered_results = dist_utils.all_gather(dict(prediction_results))
+        merged_results = defaultdict(list)
+        for rank_results in gathered_results:
+            for iou_type, rows in rank_results.items():
+                merged_results[iou_type].extend(rows)
+        prediction_results = dict(merged_results)
+
+    return stats, prediction_results
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate a Mask RT-DETR v2 checkpoint")
+    parser.add_argument("-c", "--config", type=str, required=True, help="Path to a mask RT-DETR YAML config")
+    parser.add_argument(
+        "-r",
+        "--resume",
+        "--checkpoint",
+        dest="resume",
+        type=str,
+        help="Checkpoint to evaluate, for example output/mask_rtdetrv2/best.pth",
+    )
+    parser.add_argument("-d", "--device", type=str, help="Device, for example cuda, mps, or cpu")
+    parser.add_argument("--seed", type=int, help="Evaluation seed")
+    parser.add_argument("--output-dir", type=str, help="Directory for metrics and optional predictions")
+    parser.add_argument("--metrics-file", type=str, help="Metrics JSON path. Defaults to <output-dir>/metrics.json")
+    parser.add_argument("--save-predictions", action="store_true", help="Write COCO-format prediction JSON files")
+    parser.add_argument(
+        "--prediction-prefix",
+        type=str,
+        default="predictions",
+        help="Prediction file prefix used with --save-predictions",
+    )
+    parser.add_argument("-u", "--update", nargs="+", help="YAML overrides, e.g. num_classes=2")
+    parser.add_argument("--print-method", type=str, default="builtin", help="Print method: builtin or rich")
+    parser.add_argument("--print-rank", type=int, default=0, help="Distributed rank allowed to print")
+    parser.add_argument("--local-rank", type=int, help="Local rank for distributed launchers")
+    return parser.parse_args()
+
+
+def main(args):
+    dist_utils.setup_distributed(args.print_rank, args.print_method, seed=args.seed)
+
+    update_dict = yaml_utils.parse_cli(args.update)
+    for key in ["resume", "device", "seed"]:
+        value = getattr(args, key)
+        if value is not None:
+            update_dict[key] = value
+    if args.output_dir is not None:
+        update_dict["output_dir"] = args.output_dir
+
+    cfg = YAMLConfig(args.config, **update_dict)
+    solver = TASKS[cfg.yaml_cfg["task"]](cfg)
+    solver.eval()
+
+    output_dir = Path(args.output_dir) if args.output_dir else Path(cfg.output_dir) / "eval_mask"
+    metrics_file = Path(args.metrics_file) if args.metrics_file else output_dir / "metrics.json"
+
+    stats, prediction_results = evaluate_and_collect(
+        solver.ema.module if solver.ema else solver.model,
+        solver.postprocessor,
+        solver.val_dataloader,
+        solver.evaluator,
+        solver.device,
+        save_predictions=args.save_predictions,
+    )
+
+    summary = {
+        "config": str(Path(args.config).resolve()),
+        "checkpoint": str(Path(args.resume).resolve()) if args.resume else None,
+        "device": str(solver.device),
+        "iou_types": list(solver.evaluator.iou_types),
+        "metrics": stats,
+        "metrics_named": {iou_type: _named_metrics(values) for iou_type, values in stats.items()},
+    }
+
+    if dist_utils.is_main_process():
+        output_dir.mkdir(parents=True, exist_ok=True)
+        metrics_file.parent.mkdir(parents=True, exist_ok=True)
+        metrics_file.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print(f"Wrote metrics to {metrics_file}")
+
+        if args.save_predictions:
+            for iou_type, rows in prediction_results.items():
+                prediction_file = output_dir / f"{args.prediction_prefix}_{iou_type}.json"
+                prediction_file.write_text(json.dumps(rows), encoding="utf-8")
+                print(f"Wrote {iou_type} predictions to {prediction_file}")
+
+    dist_utils.cleanup()
+
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
## Summary
This PR adds instance segmentation support for RT-DETR v2.

The implementation follows the Mask RT-DETR / PaddleDetection approach:
1.  The encoder now also produces a shared mask feature map.
2.  The decoder predicts a mask embedding for each object query.
3. Each query mask is produced by combining its mask embedding with the shared mask feature map.
4. Training uses the existing DETR matching flow, extended with mask BCE and dice costs/losses.
5. Evaluation now supports COCO `segm` metrics in addition to bbox metrics.

This also adds:

- Mask RT-DETR v2 COCO config files.
- Mask-aware dataloader collation.
- Mask post-processing for COCO evaluation.
- A standalone evaluation script that writes bbox/segm metrics and optional COCO-format predictions.

Issue - #536

I will train the model, evaluate the results and update it over here