### PR TITLE
Register AIFI pos_embed as a non-persistent buffer

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -259,8 +259,9 @@ class HybridEncoder(nn.Module):
                 pos_embed = self.build_2d_sincos_position_embedding(
                     self.eval_spatial_size[1] // stride, self.eval_spatial_size[0] // stride,
                     self.hidden_dim, self.pe_temperature)
-                setattr(self, f'pos_embed{idx}', pos_embed)
-                # self.register_buffer(f'pos_embed{idx}', pos_embed)
+                # persistent=False keeps it out of state_dict, so released
+                # checkpoints still load with strict=True
+                self.register_buffer(f'pos_embed{idx}', pos_embed, persistent=False)
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.):
@@ -294,7 +295,7 @@ class HybridEncoder(nn.Module):
                     pos_embed = self.build_2d_sincos_position_embedding(
                         w, h, self.hidden_dim, self.pe_temperature).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f'pos_embed{enc_ind}', None).to(src_flatten.device)
+                    pos_embed = getattr(self, f'pos_embed{enc_ind}', None)
 
                 memory = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = memory.permute(0, 2, 1).reshape(-1, self.hidden_dim, h, w).contiguous()

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -268,8 +268,9 @@ class HybridEncoder(nn.Module):
                 pos_embed = self.build_2d_sincos_position_embedding(
                     self.eval_spatial_size[1] // stride, self.eval_spatial_size[0] // stride,
                     self.hidden_dim, self.pe_temperature)
-                setattr(self, f'pos_embed{idx}', pos_embed)
-                # self.register_buffer(f'pos_embed{idx}', pos_embed)
+                # persistent=False keeps it out of state_dict, so released
+                # checkpoints still load with strict=True
+                self.register_buffer(f'pos_embed{idx}', pos_embed, persistent=False)
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.):
@@ -303,7 +304,7 @@ class HybridEncoder(nn.Module):
                     pos_embed = self.build_2d_sincos_position_embedding(
                         w, h, self.hidden_dim, self.pe_temperature).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f'pos_embed{enc_ind}', None).to(src_flatten.device)
+                    pos_embed = getattr(self, f'pos_embed{enc_ind}', None)
 
                 memory :torch.Tensor = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = memory.permute(0, 2, 1).reshape(-1, self.hidden_dim, h, w).contiguous()


### PR DESCRIPTION
Fixes #677.

`pos_embed` is stored with `setattr`, so it stays a CPU tensor and is copied to the device on every forward. Pageable host-to-device copies are host-synchronous, so this stalls the pipeline mid-forward rather than just costing the copy. It also makes the model impossible to capture in a CUDA graph, and `.half()` silently skips it because `Module._apply` only walks parameters and buffers.

`persistent=False` keeps it out of `state_dict`, so the released checkpoints still load with `strict=True` (verified: 0 missing / 0 unexpected).

Output is bit-identical and COCO val2017 AP is unchanged at 0.5341 across all 5000 images. Details and measurements in #677.