### PR TITLE
Pass need_weights=False to MultiheadAttention

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -145,7 +145,7 @@ class TransformerEncoderLayer(nn.Module):
         if self.normalize_before:
             src = self.norm1(src)
         q = k = self.with_pos_embed(src, pos_embed)
-        src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask)
+        src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask, need_weights=False)
 
         src = residual + self.dropout1(src)
         if not self.normalize_before:

--- a/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
@@ -203,7 +203,7 @@ class TransformerDecoderLayer(nn.Module):
         #         torch.zeros_like(attn_mask),
         #         torch.full_like(attn_mask, float('-inf'), dtype=tgt.dtype))
 
-        tgt2, _ = self.self_attn(q, k, value=tgt, attn_mask=attn_mask)
+        tgt2, _ = self.self_attn(q, k, value=tgt, attn_mask=attn_mask, need_weights=False)
         tgt = tgt + self.dropout1(tgt2)
         tgt = self.norm1(tgt)
 

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/hybrid_encoder.py
@@ -145,7 +145,7 @@ class TransformerEncoderLayer(nn.Module):
         if self.normalize_before:
             src = self.norm1(src)
         q = k = self.with_pos_embed(src, pos_embed)
-        src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask)
+        src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask, need_weights=False)
 
         src = residual + self.dropout1(src)
         if not self.normalize_before:

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
@@ -203,7 +203,7 @@ class TransformerDecoderLayer(nn.Module):
         #         torch.zeros_like(attn_mask),
         #         torch.full_like(attn_mask, float('-inf'), dtype=tgt.dtype))
 
-        tgt2, _ = self.self_attn(q, k, value=tgt, attn_mask=attn_mask)
+        tgt2, _ = self.self_attn(q, k, value=tgt, attn_mask=attn_mask, need_weights=False)
         tgt = tgt + self.dropout1(tgt2)
         tgt = self.norm1(tgt)
 

--- a/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_decoder.py
+++ b/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetrv2_decoder.py
@@ -213,7 +213,7 @@ class TransformerDecoderLayer(nn.Module):
         # self attention
         q = k = self.with_pos_embed(target, query_pos_embed)
 
-        target2, _ = self.self_attn(q, k, value=target, attn_mask=attn_mask)
+        target2, _ = self.self_attn(q, k, value=target, attn_mask=attn_mask, need_weights=False)
         target = target + self.dropout1(target2)
         target = self.norm1(target)
 


### PR DESCRIPTION
Fixes #678.

All five `nn.MultiheadAttention` call sites discard the returned attention weights (`, _ = self.self_attn(...)`), but the default `need_weights=True` forces the unfused attention path and materialises the full `[B, H, N, N]` matrix before it is thrown away. Passing `need_weights=False` routes through `scaled_dot_product_attention` instead.

COCO val2017 AP is unchanged at 0.5341 across all 5000 images, and training was checked as well as inference since SDPA's backward runs during training. Details and measurements in #678.