### PR TITLE
fix(rtdetrv2): support torchvision >= 0.16 in PadToSize and Mosaic

### DIFF
--- a/rtdetrv2_pytorch/src/data/_misc.py
+++ b/rtdetrv2_pytorch/src/data/_misc.py
@@ -2,6 +2,7 @@
 """
 
 import importlib.metadata
+from collections import defaultdict
 from torch import Tensor 
 
 if importlib.metadata.version('torchvision') == '0.15.2':
@@ -11,6 +12,7 @@ if importlib.metadata.version('torchvision') == '0.15.2':
     from torchvision.datapoints import BoundingBox as BoundingBoxes
     from torchvision.datapoints import BoundingBoxFormat, Mask, Image, Video
     from torchvision.transforms.v2 import SanitizeBoundingBox as SanitizeBoundingBoxes
+    from torchvision.transforms.v2.functional import get_spatial_size as get_size
     _boxes_keys = ['format', 'spatial_size']
 
 elif '0.17' > importlib.metadata.version('torchvision') >= '0.16':
@@ -18,6 +20,7 @@ elif '0.17' > importlib.metadata.version('torchvision') >= '0.16':
     torchvision.disable_beta_transforms_warning()
 
     from torchvision.transforms.v2 import SanitizeBoundingBoxes
+    from torchvision.transforms.v2.functional import get_size
     from torchvision.tv_tensors import (
         BoundingBoxes, BoundingBoxFormat, Mask, Image, Video)
     _boxes_keys = ['format', 'canvas_size']
@@ -25,6 +28,7 @@ elif '0.17' > importlib.metadata.version('torchvision') >= '0.16':
 elif importlib.metadata.version('torchvision') >= '0.17':
     import torchvision
     from torchvision.transforms.v2 import SanitizeBoundingBoxes
+    from torchvision.transforms.v2.functional import get_size
     from torchvision.tv_tensors import (
         BoundingBoxes, BoundingBoxFormat, Mask, Image, Video)
     _boxes_keys = ['format', 'canvas_size']
@@ -32,6 +36,15 @@ elif importlib.metadata.version('torchvision') >= '0.17':
 else:
     raise RuntimeError('Please make sure torchvision version >= 0.15.2')
 
+
+
+def get_fill(fill_dict, inpt_type):
+    # torchvision 0.15.2 keys fill by type in a defaultdict, >= 0.16 falls back to an 'others' key
+    if isinstance(fill_dict, defaultdict):
+        return fill_dict[inpt_type]
+    if inpt_type in fill_dict:
+        return fill_dict[inpt_type]
+    return fill_dict.get('others', None)
 
 
 def convert_to_tv_tensor(tensor: Tensor, key: str, box_format='xyxy', spatial_size=None) -> Tensor:

--- a/rtdetrv2_pytorch/src/data/transforms/_transforms.py
+++ b/rtdetrv2_pytorch/src/data/transforms/_transforms.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 from .._misc import convert_to_tv_tensor, _boxes_keys
 from .._misc import Image, Video, Mask, BoundingBoxes
 from .._misc import SanitizeBoundingBoxes
+from .._misc import get_size, get_fill
 
 from ...core import register
 
@@ -54,7 +55,7 @@ class PadToSize(T.Pad):
         BoundingBoxes,
     )
     def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
-        sp = F.get_spatial_size(flat_inputs[0])
+        sp = get_size(flat_inputs[0])
         h, w = self.size[1] - sp[0], self.size[0] - sp[1]
         self.padding = [0, 0, w, h]
         return dict(padding=self.padding)
@@ -69,7 +70,7 @@ class PadToSize(T.Pad):
         super().__init__(0, fill, padding_mode)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:        
-        fill = self._fill[type(inpt)]
+        fill = get_fill(self._fill, type(inpt))
         padding = params['padding']
         return F.pad(inpt, padding=padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
 

--- a/rtdetrv2_pytorch/src/data/transforms/mosaic.py
+++ b/rtdetrv2_pytorch/src/data/transforms/mosaic.py
@@ -5,12 +5,11 @@ import torch
 import torchvision
 torchvision.disable_beta_transforms_warning()
 import torchvision.transforms.v2 as T
-import torchvision.transforms.v2.functional as F
 
 import random
 from PIL import Image 
 
-from .._misc import convert_to_tv_tensor
+from .._misc import convert_to_tv_tensor, get_size
 from ...core import register
 
 
@@ -38,7 +37,7 @@ class Mosaic(T.Transform):
             images.append(image)
             targets.append(target)
 
-        h, w = F.get_spatial_size(images[0])
+        h, w = get_size(images[0])
         offset = [[0, 0], [w, 0], [0, h], [w, h]]
         image = Image.new(mode=images[0].mode, size=(w * 2, h * 2), color=0)
         for i, im in enumerate(images):


### PR DESCRIPTION
## Summary
Fix `PadToSize` and `Mosaic` in `rtdetrv2_pytorch` for torchvision 0.16+ compatibility.

`torchvision.transforms.v2.functional.get_spatial_size()` was removed in torchvision 0.16 (renamed to `get_size()`), so these transforms fail with:
`AttributeError: module 'torchvision.transforms.v2.functional' has no attribute 'get_spatial_size'`

`rtdetrv2_pytorch/requirements.txt` asks for `torchvision>=0.15.2` and the README documents torchvision up to 0.19, so every supported version except 0.15.2 is affected. These transforms are not part of the default configs, which is likely why this went unnoticed.

## Change
Add `get_size` to the existing version-dependent import block in `src/data/_misc.py` (aliased to `get_spatial_size` on 0.15.2) and use it in `PadToSize._get_params` and `Mosaic.forward`.

Add `get_fill()` to `src/data/_misc.py` for `PadToSize._transform`. `T.Pad` stores the fill argument as a type-keyed `defaultdict` on 0.15.2, but as a plain dict with an `"others"` key on 0.16+, so `self._fill[type(inpt)]` raises `KeyError: <class 'PIL.Image.Image'>` once the first error is fixed. torchvision's own `_get_fill()` cannot be reused because it does not exist on 0.15.2.

Follow-up to #629, which touched the same class.

## Verification
Ran on CPU against torchvision 0.15.2, 0.16.2 and 0.28.0, exercising all three branches of the version gate in `_misc.py`:
- Letterbox path (aspect-preserving `Resize(size=384, max_size=640)` + `PadToSize(size=640)`) on a 1333x800 input produces 640x640 with boxes unchanged
- `PadToSize(size=640, fill=114)` writes 114 into the padded region and leaves the original region untouched
- `PadToSize(size=640)` on a 640x640 input leaves the image and boxes unchanged
- `Mosaic(size=320)` completes and returns a 320x320 image
- `get_fill()` resolves the fill value for both the 0.15.2 and the 0.16+ internal representation
- The 9 default train ops from the shipped configs still pass (regression check)

Before this change, torchvision 0.16.2 and 0.28.0 fail on the `PadToSize` and `Mosaic` cases with the `AttributeError` above; 0.15.2 behaviour is unchanged.
