### PR TITLE
fix: normalize scores over classes in softmax postprocess branch

### DIFF
--- a/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
+++ b/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py
@@ -45,7 +45,7 @@ class RTDETRPostProcessor(nn.Module):
             boxes = bbox_pred.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, bbox_pred.shape[-1]))
             
         else:
-            scores = F.softmax(logits)[:, :, :-1]
+            scores = F.softmax(logits, dim=-1)[:, :, :-1]
             scores, labels = scores.max(dim=-1)
             boxes = bbox_pred
             if scores.shape[1] > self.num_top_queries:

--- a/rtdetrv2_pytorch/src/nn/postprocessor/detr_postprocessor.py
+++ b/rtdetrv2_pytorch/src/nn/postprocessor/detr_postprocessor.py
@@ -47,7 +47,7 @@ class DetDETRPostProcessor(nn.Module):
             boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
             
         else:
-            scores = F.softmax(logits)[:, :, :-1]
+            scores = F.softmax(logits, dim=-1)[:, :, :-1]
             scores, labels = scores.max(dim=-1)
             if scores.shape[1] > self.num_top_queries:
                 scores, index = torch.topk(scores, self.num_top_queries, dim=-1)


### PR DESCRIPTION
## Summary
Pass `dim=-1` to `F.softmax()` in the two DETR post-processors that still omit it, so confidence scores are normalized over classes instead of over the batch.

`F.softmax()` defaults to `dim=None`, and the implicit choice is derived from the input rank alone: `dim=0` for rank 3. `pred_logits` is `[batch, num_queries, num_classes]`, so the scores end up normalized along the batch axis. Consequences:

- With `batch=1` every score collapses to exactly `1.0`, so score thresholding has no effect
- With `batch=N` the scores sit near `1/N` regardless of the logits
- The same image yields different scores depending on the batch size it was inferred in
- PyTorch emits `UserWarning: Implicit dimension choice for softmax has been deprecated` on every call

This only affects the `use_focal_loss=False` branch; the default focal-loss path is untouched.

This is a follow-up to #661, which applied the same one-line fix to `rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py`. These are the two remaining occurrences.

## Change
Add `dim=-1` in:
- `rtdetrv2_pytorch/src/nn/postprocessor/detr_postprocessor.py`
- `rtdetr_pytorch/src/zoo/rtdetr/rtdetr_postprocessor.py`

The Paddle implementation is left alone: `paddle.nn.functional.softmax` defaults to `axis=-1`, so it is already correct there.

## Verification
Ran both post-processors on CPU with torch 2.13.0, `use_focal_loss=False`, `num_top_queries=3`:
- `batch=1` no longer returns all-`1.0` scores
- Scores and labels now match a reference computed with an explicit class-axis softmax
- The same image gives identical scores at `batch=1` and `batch=3`
- No `Implicit dimension` warning is emitted
- The `use_focal_loss=True` path produces identical scores and labels before and after (regression check)

Before this change, both files failed the first four checks with identical values (`scores=[1.0, 1.0, 1.0]` at `batch=1`, `[0.333, 0.333, 0.333]` at `batch=3`).
