### PR TITLE
fix(rtdetrv2): support torchvision wheels with a local version segment

### DIFF
--- a/rtdetrv2_pytorch/requirements.txt
+++ b/rtdetrv2_pytorch/requirements.txt
@@ -4,6 +4,7 @@ faster-coco-eval>=1.6.6
 PyYAML
 tensorboard
 scipy
+packaging
 pycocotools
 onnx
 onnxruntime-gpu

--- a/rtdetrv2_pytorch/src/data/_misc.py
+++ b/rtdetrv2_pytorch/src/data/_misc.py
@@ -3,9 +3,12 @@
 
 import importlib.metadata
 from collections import defaultdict
+from packaging import version
 from torch import Tensor 
 
-if importlib.metadata.version('torchvision') == '0.15.2':
+_torchvision_version = version.parse(importlib.metadata.version('torchvision'))
+
+if version.parse('0.16') > _torchvision_version >= version.parse('0.15.2'):
     import torchvision
     torchvision.disable_beta_transforms_warning()
 
@@ -15,7 +18,7 @@ if importlib.metadata.version('torchvision') == '0.15.2':
     from torchvision.transforms.v2.functional import get_spatial_size as get_size
     _boxes_keys = ['format', 'spatial_size']
 
-elif '0.17' > importlib.metadata.version('torchvision') >= '0.16':
+elif version.parse('0.17') > _torchvision_version >= version.parse('0.16'):
     import torchvision
     torchvision.disable_beta_transforms_warning()
 
@@ -25,7 +28,7 @@ elif '0.17' > importlib.metadata.version('torchvision') >= '0.16':
         BoundingBoxes, BoundingBoxFormat, Mask, Image, Video)
     _boxes_keys = ['format', 'canvas_size']
 
-elif importlib.metadata.version('torchvision') >= '0.17':
+elif _torchvision_version >= version.parse('0.17'):
     import torchvision
     from torchvision.transforms.v2 import SanitizeBoundingBoxes
     from torchvision.transforms.v2.functional import get_size


### PR DESCRIPTION
## Summary
Compare the torchvision version in `rtdetrv2_pytorch/src/data/_misc.py` with `packaging.version` instead of comparing the raw string, so wheels installed from the PyTorch index are recognized.

The version gate matches `importlib.metadata.version('torchvision')` against `'0.15.2'`, `'0.16'` and `'0.17'` as plain strings. Wheels from `download.pytorch.org` carry a PEP 440 local version segment (`0.15.2+cpu`, `0.15.2+cu117`, `0.15.2+cu118`), which matches none of the three branches: `== '0.15.2'` is false, and lexicographically `'0.15.2+cu118' < '0.16'`. Importing anything under `src.data` then fails with:
`RuntimeError: Please make sure torchvision version >= 0.15.2`

String comparison also lets the last branch accept versions that are far too old, since `'0.9.0' > '0.17'` lexicographically.

`requirements.txt` asks for `torchvision>=0.15.2` and the README lists `torch 2.0` / `torchvision 0.15` as a supported combination. Installing from the PyTorch index is the documented way to get a build matching a particular CUDA version, so the failure hits users following the normal setup. It has been reported in #398 (open since 2024-07, with `0.15.2+cu118`) and #562 (with `0.15.2+cu117`).

## Change
Parse the version once with `packaging.version.parse` and compare the parsed objects. `packaging` is already used for exactly this purpose in `src/data/transforms/functional.py`, which imports it unconditionally, so it was an undeclared requirement even before this change. It is now listed in `rtdetrv2_pytorch/requirements.txt`.

The branch structure and the version boundaries are unchanged (`[0.15.2, 0.16)`, `[0.16, 0.17)`, `>= 0.17`, otherwise `RuntimeError`); only the comparisons are replaced. The first branch becomes a range check rather than an equality check, which is what allows `0.15.2+cu118` to select it.

## Verification
Exercised branch selection on CPU for a matrix of reported versions, by patching `importlib.metadata.version` and loading `_misc.py` in a fresh subprocess per case. The branch taken is observed rather than re-derived from the version string: `RuntimeError` for rejection, `ImportError` on `torchvision.datapoints` or `_boxes_keys == ['format', 'spatial_size']` for the 0.15.2 branch, and whether `disable_beta_transforms_warning()` is called to separate the 0.16 branch from the 0.17+ branch.

- `0.15.2+cpu`, `0.15.2+cu117` and `0.15.2+cu118` select the 0.15.2 branch
- `0.15.2`, `0.16.0`, `0.16.0+cpu`, `0.16.2+cu121`, `0.17.0`, `0.19.1+cu121` and `0.28.0+cpu` select the same branch as before
- `0.14.1` and `0.15.1` are still rejected
- Importing `src.data` with the installed torchvision (0.28.0+cpu) and running `PadToSize` → `ConvertPILImage` → `ConvertBoxes` gives identical output before and after the change: padding `[0, 0, 24, 34]`, normalized boxes `[0.1641, 0.2109, 0.2969, 0.3594]` (regression check)

Before this change, the three `0.15.2+*` cases matched no branch and raised the `RuntimeError` above; every other case is unchanged.
