### PR TITLE
README: add a community Android (LiteRT GPU) port under Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ By harnessing the rapidly evolving capabilities of Vision Foundation Models (VFM
 - 🔥 RT-DETR 
   - paddle: [code&weight](./rtdetr_paddle)
   - pytorch: [code&weight](./rtdetr_pytorch)
+- Community ports
+  - Android (LiteRT GPU): [code&weight](https://github.com/john-rocky/LiteRT-Models#rt-detrv2-s) — RT-DETRv2-S on the LiteRT CompiledModel GPU with a Kotlin sample app, ~615 ms/frame on a Pixel 8a (still-image)
 
 
 | Model | Input shape | Dataset | $AP^{val}$ | $AP^{val}_{50}$| Params(M) | FLOPs(G) | T4 TensorRT FP16(FPS)


### PR DESCRIPTION
Thanks for the Implementations list. This adds a "Community ports" entry to it for an Android build of RT-DETRv2-S: the `rtdetr_v2_r18vd` weights converted to LiteRT (.tflite) and running fully on the phone GPU through the LiteRT CompiledModel API, with a Kotlin sample app.

- Pixel 8a: both graphs fully GPU-resident; about 615 ms per frame end-to-end, so still-image use rather than real-time. The number is in the line so nobody expects otherwise.
- Detections match PyTorch at IoU 0.98–1.00 on COCO val images (giraffe 7/7, cats 6/6).
- Apache-2.0 is kept, and the zoo section links back to this repo.

Zoo section: https://github.com/john-rocky/LiteRT-Models#rt-detrv2-s — weights: https://huggingface.co/litert-community/RT-DETRv2-S-LiteRT

Happy to shorten the line or drop it if you would rather keep the list to official implementations. Thanks again.
