### PR TITLE
Add optional ultrafast COCO evaluator to RT-DETRv2

### DIFF
--- a/.github/workflows/coco-backends.yml
+++ b/.github/workflows/coco-backends.yml
@@ -1,0 +1,38 @@
+name: COCO evaluation backends
+
+on:
+  pull_request:
+    paths:
+      - "rtdetrv2_pytorch/src/**"
+      - "rtdetrv2_pytorch/tests/**"
+      - ".github/workflows/coco-backends.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+        faster-coco-eval: ["1.6.6", "1.7.2"]
+    env:
+      PYTHONPATH: .
+      RAYON_NUM_THREADS: "2"
+      OMP_NUM_THREADS: "2"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install CPU evaluation test dependencies
+        run: |
+          python -m pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install pytest numpy scipy pillow packaging pyyaml tensorboard pycocotools "faster-coco-eval==${{ matrix.faster-coco-eval }}" "ultrafast-pycocotools>=0.1.11,<0.2"
+      - name: Test arrays, summaries, YAML, cleanup and distributed aggregation
+        working-directory: rtdetrv2_pytorch
+        run: python -m pytest -v tests/test_coco_backend.py

--- a/rtdetrv2_pytorch/README.md
+++ b/rtdetrv2_pytorch/README.md
@@ -29,6 +29,50 @@ The following is the corresponding `torch` and `torchvision` versions.
 </details>
 
 
+## Optional COCO evaluation backend
+
+RT-DETRv2's PyTorch evaluator uses `faster-coco-eval` by default. To select
+[ultrafast-pycocotools](https://github.com/developer0hye/ultrafast-pycocotools), install:
+
+```shell
+pip install "ultrafast-pycocotools>=0.1.11,<0.2"
+```
+
+Then add the backend to your evaluator configuration:
+
+```yaml
+evaluator:
+  type: CocoEvaluator
+  iou_types: ['bbox']
+  backend: ultrafast
+```
+
+Alternatively, append `-u evaluator.backend=ultrafast` to a training or
+`--test-only` command. The default dependencies, including faster-coco-eval for
+COCO datasets and summary formatting, are still required.
+
+The optional backend performs native matching and accumulation after gathering
+prepared predictions and removing duplicate image IDs in rank/batch order.
+It retains the existing `stats`, `stats_as_dict`, custom detection caps, area ranges
+and cleanup between evaluation epochs. Mask encoding is batched per image.
+The existing faster-coco-eval summary implementation is reused, including its
+custom maxDets and LVIS-style output semantics. `lvis_style=True` uses
+ultrafast's `coco` protocol to match faster-coco-eval, rather than the separate
+LVIS evaluator's global detection-cap protocol.
+
+This option applies to `rtdetrv2_pytorch`. Evaluation results become available
+through the usual synchronize/accumulate/summarize calls. Backend selection is
+local to the evaluator and does not replace process-wide imports. This changes
+where evaluation work happens; compare the complete evaluation lifecycle when
+measuring performance.
+
+With both evaluators and pytest installed, run the parity and CPU/Gloo tests from
+this directory:
+
+```shell
+PYTHONPATH=. python -m pytest tests/test_coco_backend.py
+```
+
 ## Model Zoo
 
 ### Base models

--- a/rtdetrv2_pytorch/src/data/dataset/coco_eval.py
+++ b/rtdetrv2_pytorch/src/data/dataset/coco_eval.py
@@ -8,9 +8,161 @@ in the end of the file, as python3 can suppress prints with contextlib
 # MiXaiLL76 replacing pycocotools with faster-coco-eval for better performance and support.
 """
 
-from ...core import register
+import copy
+import io
+from contextlib import redirect_stdout
+
+import numpy as np
+import torch.distributed as dist
+from faster_coco_eval import COCOeval_faster
 from faster_coco_eval.utils.pytorch import FasterCocoEvaluator
+
+from ...core import register
+
+
+def _ultrafast_tools():
+    try:
+        from ultrafast_pycocotools import COCO, COCOeval
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            'Install the optional evaluator with pip install "ultrafast-pycocotools>=0.1.11,<0.2".'
+        ) from exc
+    return COCO, COCOeval
+
+
+class _UltrafastCOCOeval(COCOeval_faster):
+    """Native matching/accumulation with the existing faster-coco-eval summaries."""
+
+    def __init__(self, coco_gt, iouType, **kwargs):
+        super().__init__(None, iouType=iouType, **kwargs)
+        self.cocoGt = coco_gt
+        self.params.imgIds = sorted(coco_gt.getImgIds())
+        self.params.catIds = sorted(coco_gt.catToImgs if iouType == "keypoints" else coco_gt.getCatIds())
+
+    def evaluate(self):
+        self.params.imgIds = list(np.unique(self.params.imgIds))
+        if self.params.useCats:
+            self.params.catIds = list(np.unique(self.params.catIds))
+        self.params.maxDets = sorted(self.params.maxDets)
+        _, evaluator = _ultrafast_tools()
+        self._native = evaluator(
+            self.cocoGt,
+            self.cocoDt,
+            self.params.iouType,
+            lvis_style=self.lvis_style,
+            lvis_protocol="coco",
+            print_function=self.print_function,
+        )
+        # Do not assign Faster Params wholesale: its deprecated useSegm property
+        # would reinterpret keypoints as bbox in the reference-compatible API.
+        for name in (
+            "imgIds",
+            "catIds",
+            "iouThrs",
+            "recThrs",
+            "maxDets",
+            "areaRng",
+            "areaRngLbl",
+            "useCats",
+            "kpt_oks_sigmas",
+        ):
+            if hasattr(self.params, name):
+                setattr(self._native.params, name, copy.deepcopy(getattr(self.params, name)))
+        self._native.evaluate()
+        self._paramsEval = copy.deepcopy(self.params)
+        if self.lvis_style:
+            self.freq_groups = self._prepare_freq_group()
+
+    def accumulate(self):
+        self._native.accumulate()
+        self.eval = dict(self._native.eval)
+        self.eval["params"] = self.params
+
 
 @register()
 class CocoEvaluator(FasterCocoEvaluator):
-    pass
+    def __init__(self, coco_gt, iou_types, lvis_style=False, ranges=None, backend="faster_coco_eval"):
+        if backend not in ("faster_coco_eval", "ultrafast"):
+            raise ValueError(f"Unknown COCO backend {backend!r}")
+        self.backend = backend
+        self._range_kwargs = {} if ranges is None else {"ranges": ranges}
+        if backend == "ultrafast":
+            coco_class, _ = _ultrafast_tools()
+        super().__init__(coco_gt, iou_types, lvis_style=lvis_style, **self._range_kwargs)
+        if backend == "ultrafast":
+            # Reuse the already-copied dataset, keeping the caller's object intact.
+            self.coco_gt = coco_class(self.coco_gt.dataset, verbose=False)
+            self.cleanup()
+
+    def cleanup(self):
+        if self.backend == "faster_coco_eval":
+            return super().cleanup()
+        self.coco_eval = {
+            iou_type: _UltrafastCOCOeval(
+                self.coco_gt,
+                iouType=iou_type,
+                lvis_style=self.lvis_style,
+                print_function=print,
+                separate_eval=True,
+                **self._range_kwargs,
+            )
+            for iou_type in self.iou_types
+        }
+        self.img_ids = []
+        self.eval_imgs = {key: [] for key in self.iou_types}
+        self.stats_as_dict = {key: [] for key in self.iou_types}
+        self._predictions = {key: {} for key in self.iou_types}
+
+    def prepare_for_coco_segmentation(self, predictions):
+        if self.backend == "faster_coco_eval":
+            return super().prepare_for_coco_segmentation(predictions)
+        from ultrafast_pycocotools import mask as mask_util
+
+        results = []
+        for image_id, prediction in predictions.items():
+            if not prediction or len(prediction["masks"]) == 0:
+                continue
+            masks = prediction["masks"][:, 0].detach().cpu().numpy() > 0.5
+            rles = mask_util.encode(np.asfortranarray(masks.transpose(1, 2, 0), dtype=np.uint8))
+            for rle, label, score in zip(rles, prediction["labels"].tolist(), prediction["scores"].tolist()):
+                rle["counts"] = rle["counts"].decode("utf-8")
+                results.append({"image_id": image_id, "category_id": int(label), "score": score, "segmentation": rle})
+        return results
+
+    def update(self, predictions):
+        if self.backend == "faster_coco_eval":
+            return super().update(predictions)
+        image_ids = sorted(predictions)
+        self.img_ids.extend(image_ids)
+        for iou_type in self.iou_types:
+            per_image = {image_id: [] for image_id in image_ids}
+            for result in self.prepare(predictions, iou_type):
+                per_image[result["image_id"]].append(result)
+            for image_id in image_ids:
+                self._predictions[iou_type].setdefault(image_id, per_image[image_id])
+
+    def synchronize_between_processes(self):
+        if self.backend == "faster_coco_eval":
+            return super().synchronize_between_processes()
+        actual_size = dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
+        world_size = actual_size if self.world_size is None else self.world_size
+        if world_size not in (1, actual_size):
+            raise ValueError("world_size must be 1 or match the initialized process group")
+        for iou_type in self.iou_types:
+            gathered = [self._predictions[iou_type]]
+            if world_size > 1:
+                gathered = [None] * world_size
+                dist.all_gather_object(gathered, self._predictions[iou_type])
+            merged = {}
+            for per_rank in gathered:
+                for image_id, predictions in per_rank.items():
+                    merged.setdefault(image_id, predictions)
+            # Match the existing merge: sorted IDs and first occurrence in rank/batch order.
+            image_ids = sorted(merged)
+            results = [item for image_id in image_ids for item in merged[image_id]]
+            evaluator = self.coco_eval[iou_type]
+            with redirect_stdout(io.StringIO()):
+                evaluator.cocoDt = self.coco_gt.loadRes(results)
+                evaluator.params.imgIds = image_ids
+                evaluator.evaluate()
+            self._predictions[iou_type].clear()

--- a/rtdetrv2_pytorch/tests/test_coco_backend.py
+++ b/rtdetrv2_pytorch/tests/test_coco_backend.py
@@ -1,0 +1,254 @@
+import builtins
+import copy
+import inspect
+import json
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from faster_coco_eval.utils.pytorch import FasterCocoEvaluator
+from src.core import GLOBAL_CONFIG, create
+from src.data.dataset.coco_eval import CocoEvaluator
+
+pytest.importorskip("ultrafast_pycocotools")
+
+
+def _inputs():
+    from faster_coco_eval import COCO
+
+    keypoints = [[3 + i % 4, 4 + i // 4, 2] for i in range(17)]
+    ann = {
+        "id": 1,
+        "image_id": 1,
+        "category_id": 1,
+        "iscrowd": 0,
+        "bbox": [2, 2, 12, 12],
+        "area": 144,
+        "segmentation": [[2, 2, 14, 2, 14, 14, 2, 14]],
+        "keypoints": np.asarray(keypoints).flatten().tolist(),
+        "num_keypoints": 17,
+    }
+    gt = COCO()
+    gt.dataset = {
+        "info": {},
+        "images": [{"id": i, "width": 32, "height": 32} for i in (1, 2, 3)],
+        "categories": [{"id": 1, "name": "person"}],
+        "annotations": [ann, dict(ann, id=2, image_id=2, iscrowd=1)],
+    }
+    for image in gt.dataset["images"]:
+        image.update(neg_category_ids=[], not_exhaustive_category_ids=[])
+    for category in gt.dataset["categories"]:
+        category["frequency"] = "c"
+    gt.createIndex()
+    masks = torch.zeros((3, 1, 32, 32))
+    masks[0, :, 18:30, 18:30] = 1
+    masks[1:, :, 2:14, 2:14] = 1
+    pose = torch.tensor(keypoints, dtype=torch.float32)
+    shifted_pose = pose.clone()
+    shifted_pose[:, :2] += 16
+    prediction = {
+        "boxes": torch.tensor([[18.0, 18.0, 30.0, 30.0], [2.0, 2.0, 14.0, 14.0], [2.0, 2.0, 14.0, 14.0]]),
+        "scores": torch.tensor([0.9, 0.8, 0.8]),
+        "labels": torch.ones(3, dtype=torch.int64),
+        "masks": masks,
+        "keypoints": torch.stack([shifted_pose, pose, pose]),
+    }
+    return gt, {1: prediction, 2: {}, 3: {}}
+
+
+def _finish(evaluator):
+    evaluator.synchronize_between_processes()
+    evaluator.accumulate()
+    evaluator.summarize()
+
+
+def _assert_equal(candidate, reference):
+    for iou_type in reference.iou_types:
+        actual, expected = candidate.coco_eval[iou_type], reference.coco_eval[iou_type]
+        assert actual.params.imgIds == expected.params.imgIds
+        for key in ("precision", "recall", "scores"):
+            np.testing.assert_array_equal(actual.eval[key], expected.eval[key])
+        np.testing.assert_array_equal(actual.stats, expected.stats)
+        np.testing.assert_array_equal(actual.all_stats, expected.all_stats)
+    assert candidate.stats_as_dict == reference.stats_as_dict
+
+
+@pytest.mark.parametrize("iou_types", [["bbox"], ["segm"], ["keypoints"], ["bbox", "segm", "keypoints"]])
+@pytest.mark.parametrize("cap", [None, 500])
+@pytest.mark.parametrize("lvis_style", [False, True])
+def test_complete_outputs_and_cleanup(iou_types, cap, lvis_style):
+    gt, predictions = _inputs()
+    if lvis_style:
+        gt.dataset["categories"].extend(
+            [
+                {"id": 2, "name": "rare", "frequency": "r"},
+                {"id": 3, "name": "frequent", "frequency": "f"},
+            ]
+        )
+        gt.dataset["annotations"].append(dict(gt.dataset["annotations"][0], id=3, image_id=2, category_id=2))
+        gt.dataset["images"][0]["not_exhaustive_category_ids"] = [1]
+        gt.dataset["images"][2]["neg_category_ids"] = [1]
+        predictions[3] = {key: value[:2].clone() for key, value in predictions[1].items()}
+        predictions[3]["labels"] = torch.tensor([1, 3])
+        gt.createIndex()
+    original = copy.deepcopy(gt.dataset)
+    candidate = CocoEvaluator(gt, iou_types, lvis_style=lvis_style, backend="ultrafast")
+    reference = FasterCocoEvaluator(gt, iou_types, lvis_style=lvis_style)
+    for epoch in range(2):
+        for evaluator in (reference, candidate):
+            evaluator.cleanup()
+            assert evaluator.img_ids == []
+            if cap:
+                for metric, evaluation in evaluator.coco_eval.items():
+                    evaluation.params.maxDets = [cap] if metric == "keypoints" else [cap, 1, 10]
+            # The next epoch has different predictions, exposing stale result reuse.
+            item = predictions[1] if epoch == 0 else {k: v[:1] for k, v in predictions[1].items()}
+            evaluator.update({1: item})
+            evaluator.update({2: {}, 3: predictions[3]})
+            evaluator.update({1: {k: v[:1] for k, v in predictions[1].items()}})
+            _finish(evaluator)
+        _assert_equal(candidate, reference)
+        candidate.accumulate()
+        candidate.summarize()
+        _assert_equal(candidate, reference)
+    assert gt.dataset == original
+
+
+@pytest.mark.skipif(
+    "ranges" not in inspect.signature(FasterCocoEvaluator).parameters, reason="ranges added after 1.6.6"
+)
+def test_custom_ranges():
+    gt, predictions = _inputs()
+    kwargs = dict(iou_types=["bbox", "segm"], ranges={"tiny": [0, 16], "other": [16, 1e10]})
+    reference, candidate = FasterCocoEvaluator(gt, **kwargs), CocoEvaluator(gt, backend="ultrafast", **kwargs)
+    for evaluator in (reference, candidate):
+        evaluator.update(predictions)
+        _finish(evaluator)
+    _assert_equal(candidate, reference)
+
+
+def test_yaml_registry_and_errors(monkeypatch):
+    gt, predictions = _inputs()
+    # Use the actual project registry, with the same create('evaluator', ...) path as YAMLConfig.
+    config = dict(GLOBAL_CONFIG)
+    config["CocoEvaluator"] = dict(GLOBAL_CONFIG["CocoEvaluator"])
+    config.update(yaml.safe_load("evaluator: {type: CocoEvaluator, iou_types: [bbox], backend: ultrafast}"))
+    candidate = create("evaluator", config, coco_gt=gt)
+    assert candidate.backend == "ultrafast"
+    candidate.update(predictions)
+    _finish(candidate)
+    with pytest.raises(ValueError, match="Unknown COCO backend"):
+        CocoEvaluator(gt, ["bbox"], backend="invalid")
+    original_import = builtins.__import__
+
+    def no_ultrafast(name, *args, **kwargs):
+        if name.startswith("ultrafast_pycocotools"):
+            raise ModuleNotFoundError(name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_ultrafast)
+    with pytest.raises(ModuleNotFoundError, match="ultrafast-pycocotools>=0.1.11"):
+        CocoEvaluator(gt, ["bbox"], backend="ultrafast")
+    assert CocoEvaluator(gt, ["bbox"]).backend == "faster_coco_eval"
+
+
+@pytest.mark.parametrize("empty", [False, True])
+def test_empty_predictions(empty):
+    gt, predictions = _inputs()
+    candidate = CocoEvaluator(gt, ["bbox"], backend="ultrafast")
+    reference = FasterCocoEvaluator(gt, ["bbox"])
+    for evaluator in (reference, candidate):
+        evaluator.update({i: {} for i in predictions} if empty else predictions)
+        _finish(evaluator)
+    _assert_equal(candidate, reference)
+
+
+def _distributed_worker(rank, init_file, empty_rank):
+    torch.distributed.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=2)
+    try:
+        gt, predictions = _inputs()
+        candidate = CocoEvaluator(gt, ["bbox", "segm", "keypoints"], backend="ultrafast")
+        if empty_rank:
+            local = predictions if rank == 0 else {}
+        elif rank == 0:
+            local = {1: predictions[1]}
+        else:
+            local = dict(predictions)
+            local[1] = {k: v[:1] for k, v in predictions[1].items()}
+        candidate.update(local)
+        _finish(candidate)
+        # faster-coco-eval's distributed transport requires CUDA; use its single-process
+        # evaluator over the expected deduplicated dataset as the CPU/Gloo oracle.
+        reference = FasterCocoEvaluator(gt, candidate.iou_types)
+        reference.world_size = 1
+        reference.update(predictions)
+        _finish(reference)
+        _assert_equal(candidate, reference)
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.distributed.is_gloo_available(), reason="requires Gloo")
+@pytest.mark.parametrize("empty_rank", [False, True])
+def test_distributed_predictions(tmp_path, empty_rank):
+    torch.multiprocessing.spawn(_distributed_worker, args=(str(tmp_path / "gloo"), empty_rank), nprocs=2, join=True)
+
+
+def test_yaml_config_and_engine(tmp_path):
+    from src.core import YAMLConfig, yaml_utils
+    from src.solver.det_engine import evaluate
+
+    gt, predictions = _inputs()
+
+    annotations = tmp_path / "annotations.json"
+    annotations.write_text(json.dumps(gt.dataset))
+    path = tmp_path / "evaluation.yml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "evaluator": {"type": "CocoEvaluator", "iou_types": ["bbox", "segm"]},
+                "val_dataloader": {
+                    "type": "DataLoader",
+                    "batch_size": 1,
+                    "shuffle": False,
+                    "num_workers": 0,
+                    "dataset": {
+                        "type": "CocoDetection",
+                        "img_folder": str(tmp_path),
+                        "ann_file": str(annotations),
+                        "transforms": None,
+                    },
+                },
+            }
+        )
+    )
+    cfg = YAMLConfig(str(path), **yaml_utils.parse_cli(["evaluator.backend=ultrafast"]))
+    candidate = cfg.evaluator
+    assert candidate.backend == "ultrafast"
+    assert cfg.evaluator is candidate
+    reference = CocoEvaluator(gt, ["bbox", "segm"])
+    samples = torch.tensor([[1], [2], [3]])
+    targets = [{"image_id": torch.tensor(i), "orig_size": torch.tensor([32, 32])} for i in (1, 2, 3)]
+    for epoch in range(2):
+        current = copy.deepcopy(predictions)
+        if epoch:
+            current[1] = {k: v[:1] for k, v in current[1].items()}
+
+        def postprocess(outputs, sizes):
+            return [current[int(row[0])] for row in outputs]
+
+        results = []
+        for evaluator in (reference, candidate):
+            stats, returned = evaluate(
+                torch.nn.Identity(),
+                torch.nn.Identity(),
+                postprocess,
+                [(samples, targets)],
+                evaluator,
+                torch.device("cpu"),
+            )
+            assert returned is evaluator
+            results.append(stats)
+        assert results[0] == results[1]
+        _assert_equal(candidate, reference)


### PR DESCRIPTION
Adds an optional `backend: ultrafast` to RT-DETRv2's PyTorch `CocoEvaluator`. Users can set it in YAML or append `-u evaluator.backend=ultrafast` to existing training/test-only commands after installing `ultrafast-pycocotools>=0.1.11,<0.2`. The default faster-coco-eval path and existing dataset dependencies are retained.

The adapter gathers prepared predictions, keeps the first occurrence of duplicate image IDs in rank/batch order, and runs ultrafast's native matching and accumulation after synchronization. It reuses faster-coco-eval's existing summary implementation, preserving custom maxDets, area ranges, `stats`, `all_stats` and `stats_as_dict`. Segmentation masks are encoded in a batch per image. `cleanup()` creates fresh evaluators and clears cached predictions between epochs. Imports remain local to the selected backend.

LVIS-style evaluation uses ultrafast's `coco` protocol to retain faster-coco-eval's federated filtering and per-category cap semantics. The tests exercise rare/common/frequent groups, verified-negative and unverified categories, and non-exhaustive categories.

### Validation

- macOS, Python 3.12 / Torch 2.14 / faster-coco-eval 1.7.2: **23 passed**.
- Linux, Python 3.12 / Torch 2.10 CPU / faster-coco-eval 1.7.2: **23 passed**.
- Minimum supported faster-coco-eval 1.6.6: **22 passed, 1 skipped** (custom ranges are unavailable in that version).
- Zero-tolerance comparison of bbox, segmentation and keypoint precision/recall/scores arrays and every summary output, including unordered custom caps, tied scores, false positives, crowds, empty predictions, duplicate IDs and cleanup with different next-epoch predictions.
- Two actual Gloo ranks, including an empty rank, match a single-process faster-coco-eval reference over the expected unique images. The reference library's distributed transport requires CUDA; its own multi-GPU transport and NCCL were not tested here.
- The actual YAMLConfig/dataset/registry path accepts the CLI override; the existing `det_engine.evaluate()` loop produces identical saved-stat values across two evaluation epochs using fixed model outputs.
- Focused Ruff lint/format checks and `git diff --check` passed. A CPU CI matrix covers Python 3.10/3.12 and faster-coco-eval 1.6.6/1.7.2.

This PR is scoped to `rtdetrv2_pytorch`, the evaluator identified for the initial integration. It does not change the v1 or Paddle implementations. No model-inference or full-lifecycle speedup/memory reduction is claimed from standalone library benchmarks.

I maintain [ultrafast-pycocotools](https://github.com/developer0hye/ultrafast-pycocotools), which is BSD-2-Clause licensed.
